### PR TITLE
Update SUBMARINER_BROKER_URL to use https endpoint

### DIFF
--- a/submariner-k8s-broker/templates/NOTES.txt
+++ b/submariner-k8s-broker/templates/NOTES.txt
@@ -2,7 +2,7 @@ The Submariner Kubernetes Broker is now setup.
 
 You can retrieve the server URL by running
 
-  $ SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[0].port}")
+  $ SUBMARINER_BROKER_URL=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
 
 The broker client token and CA can be retrieved by running
 


### PR DESCRIPTION
Normally in a vanilla kubernetes deployment, there is a single endpoint for kubernetes.
However, in some deployments (like OpenShift), there could be multiple endpoints.

This patch updates the SUBMARINER_BROKER_URL to use the appropriate "https" endpoint.