### PR TITLE
Update route-agent-ds with Cluster/SVC CIDR values

### DIFF
--- a/submariner/templates/route-agent-ds.yaml
+++ b/submariner/templates/route-agent-ds.yaml
@@ -37,6 +37,10 @@ spec:
           value: "{{ .Values.submariner.clusterId }}"
         - name: SUBMARINER_DEBUG
           value: "{{ .Values.submariner.debug }}"
+        - name: SUBMARINER_CLUSTERCIDR                                                                                                                                                        
+          value: "{{ .Values.submariner.clusterCidr }}"
+        - name: SUBMARINER_SERVICECIDR
+          value: "{{ .Values.submariner.serviceCidr }}"
         resources:
 {{ toYaml .Values.routeAgent.resources | indent 10 }}
         securityContext:


### PR DESCRIPTION
As part of enhancing Submariner to use VxLAN overlay tunnels for preserving Source IPs, we need the POD/SVC Cidr information in the submariner-route-agent daemon set pod. This patch includes them as environment variables.