### PR TITLE
Fix iptables/nftables issue

### DIFF
--- a/submariner/templates/route-agent-ds.yaml
+++ b/submariner/templates/route-agent-ds.yaml
@@ -47,6 +47,11 @@ spec:
           privileged: true
           readOnlyRootFilesystem: false
           runAsNonRoot: false
+        volumeMounts:
+        # Because we don't actually run iptables locally, but chroot in to the host
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
 {{- with .Values.routeAgent.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -59,3 +64,7 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      volumes:
+      - name: host-slash
+        hostPath:
+          path: /


### PR DESCRIPTION
Both iptables and nftables use netfilter framework in the kernel for
packet filtering. Many distributions are moving in the direction of
using nftables over iptables. Although, nftables uses a new command
line utility (named nft), starting from iptables >=1.8, it uses
nftables under the hood while continuing to support the same iptables
syntax from the user.

Quoting from Dan's comment [#]

"In iptables 1.8, the maintainers have "deprecated" the classic ip_tables:
the iptables tool now does userspace translation from the legacy UI/UX,
and uses nf_tables under the hood. So, the commands look and feel the
same, but they're now programming a different kernel subsystem.

The problem arises when you mix and match invocations of iptables 1.6
(the previous stable) and 1.8 on the same machine, because although they
look identical, they're programming different kernel subsystems.

Empirically, this causes weird and wonderful things to happen - things
like if you trace a packet coming from a pod, you see it flowing through
both ip_tables and nf_tables, but even if both accept the packet, it then
vanishes entirely and never gets forwarded"

So, as long as we are programming either nf_tables or iptables, we would
not have any issues. Currently, there is no easy way to identify what type
of rules are programmed on the host. This patch follows the same approach
(as described here [*]) that is taken in OpenShift where the host file
system is mounted inside the docker container and iptables utility on the
host is exec'ed for programming any firewall rules.

[#] https://github.com/kubernetes/kubernetes/issues/71305#issuecomment-448052889
[*] https://github.com/kubernetes/kubernetes/issues/71305#issuecomment-521978797