### PR TITLE
Add RBAC policy for listing pods in sm-route-agent ds pod

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -32,6 +32,9 @@ rules:
 - apiGroups: ["submariner.io"]
   resources: ["clusters", "endpoints"]
   verbs: ["create", "get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Submariner-route-agent daemonset pod needs to query the list of other sm-route-agent
pods in the cluster for their hostIP addresses. The ipaddress will be used as remote
VxLAN Vtep IPs. Currently, sm-route-agent pod does not have the necessary privileges
to list the pods in the submariner namespace of local cluster. This patch addresses
this issue by adding the necessary role.

Error seen:
Failed to list *v1.Pod: pods is forbidden: User
"system:serviceaccount:submariner:submariner-routeagent" cannot list resource "pods"
in API group "" in the namespace "submariner"