### PR TITLE
Add support for the Globalnet controller

### DIFF
--- a/submariner/templates/_helpers.tpl
+++ b/submariner/templates/_helpers.tpl
@@ -52,3 +52,14 @@ Create the name of the submariner-route-agent service account to use
     {{ default "default" .Values.serviceAccounts.routeAgent.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the submariner-globalnet service account to use
+*/}}
+{{- define "submariner.globalnetServiceAccountName" -}}
+{{- if .Values.serviceAccounts.globalnet.create -}}
+    {{ default (printf "%s-globalnet" (include "submariner.fullname" .)) .Values.serviceAccounts.globalnet.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccounts.globalnet.name }}
+{{- end -}}
+{{- end -}}

--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -60,6 +60,8 @@ spec:
           value: "{{ .Values.submariner.clusterCidr }}"
         - name: SUBMARINER_SERVICECIDR
           value: "{{ .Values.submariner.serviceCidr }}"
+        - name: SUBMARINER_GLOBALCIDR
+          value: "{{ .Values.submariner.globalCidr }}"
         - name: SUBMARINER_TOKEN
           value: "{{ .Values.submariner.apiToken }}"
         - name: SUBMARINER_CLUSTERID

--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.submariner.globalCidr "" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -21,11 +22,7 @@ spec:
       serviceAccountName: submariner-globalnet
       serviceAccount: submariner-globalnet
       nodeSelector:
-{{- if eq .Values.submariner.globalCidr "" }}
-        nowhere: 'noplace'
-{{- else }}
         submariner.io/gateway: 'true'
-{{- end }}
       containers:
         - name: {{ template "submariner.fullname" . }}-globalnet
           image: submariner-globalnet:local
@@ -33,8 +30,6 @@ spec:
           env:
             - name: SUBMARINER_CLUSTERID
               value: '{{ .Values.submariner.clusterId }}'
-            - name: SUBMARINER_GLOBALCIDR
-              value: '{{ .Values.submariner.globalCidr }}'
             - name: SUBMARINER_EXCLUDENS
               value: 'submariner,kube-system,operators'
             - name: SUBMARINER_NAMESPACE
@@ -56,4 +51,4 @@ spec:
         - name: host-slash
           hostPath:
             path: /
-
+{{- end }}

--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "submariner.fullname" . }}-globalnet
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "submariner.chart" . }}
+    app: {{ template "submariner.fullname" . }}-globalnet
+    component: globalnet
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "submariner.fullname" . }}-globalnet
+  template:
+    metadata:
+      labels:
+        app: {{ template "submariner.fullname" . }}-globalnet
+    spec:
+      hostNetwork: true
+      serviceAccountName: submariner-globalnet
+      serviceAccount: submariner-globalnet
+      nodeSelector:
+{{- if eq .Values.submariner.globalCidr "" }}
+        nowhere: 'noplace'
+{{- else }}
+        submariner.io/gateway: 'true'
+{{- end }}
+      containers:
+        - name: {{ template "submariner.fullname" . }}-globalnet
+          image: submariner-globalnet:local
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SUBMARINER_CLUSTERID
+              value: '{{ .Values.submariner.clusterId }}'
+            - name: SUBMARINER_GLOBALCIDR
+              value: '{{ .Values.submariner.globalCidr }}'
+            - name: SUBMARINER_EXCLUDENS
+              value: 'submariner,kube-system,operators'
+            - name: SUBMARINER_NAMESPACE
+              value: '{{ .Release.Namespace }}'
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - ALL
+            privileged: true
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false
+          volumeMounts:
+            # Because we don't actually run iptables locally, but chroot in to the host
+            - mountPath: /host
+              name: host-slash
+              readOnly: true
+      volumes:
+        - name: host-slash
+          hostPath:
+            path: /
+

--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -61,4 +61,34 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "submariner.routeAgentServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+---
+{{- if ne .Values.submariner.globalCidr "" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "submariner.fullname" . }}:globalnet
+rules:
+- apiGroups: [""]
+  resources: ["services", "namespaces", "pods"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+- apiGroups: ["submariner.io"]
+  resources: ["endpoints"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "submariner.fullname" . }}:globalnet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "submariner.fullname" . }}:globalnet
+subjects:
+- kind: ServiceAccount
+  name: {{ template "submariner.globalnetServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
 {{- end -}}

--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -75,7 +75,7 @@ rules:
   resources: ["nodes"]
   verbs: ["get"]
 - apiGroups: ["submariner.io"]
-  resources: ["endpoints"]
+  resources: ["endpoints", "clusters"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/submariner/templates/svc-acct.yaml
+++ b/submariner/templates/svc-acct.yaml
@@ -21,3 +21,15 @@ metadata:
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
 {{- end }}
+---
+{{- if .Values.serviceAccounts.globalnet.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "submariner.globalnetServiceAccountName" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: {{ template "submariner.chart" . }}
+    app: {{ template "submariner.name" . }}
+{{- end }}

--- a/submariner/values.yaml
+++ b/submariner/values.yaml
@@ -56,3 +56,6 @@ serviceAccounts:
   routeAgent:
     create: true
     name: ""
+  globalnet:
+    create: false
+    name: ""

--- a/submariner/values.yaml
+++ b/submariner/values.yaml
@@ -4,6 +4,7 @@ submariner:
   token: ""
   clusterCidr: "10.42.0.0/16"
   serviceCidr: "10.43.0.0/16"
+  globalCidr: ""
   natEnabled: false
   colorCodes: blue
   debug: false


### PR DESCRIPTION
Added a chart for the ipam controller which uses the global CIDR.
Also added the global CIDR to the submariner engine pod env so it can
utilize it.
The IPAM controller will only be deployed if the CIDR is specified.