### PR TITLE
Update Submariner Engine to a DaemonSet

### DIFF
--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   labels:
     heritage: {{ .Release.Service | quote }}
@@ -9,16 +9,13 @@ metadata:
     component: engine
   name: {{ template "submariner.fullname" . }}
 spec:
-  progressDeadlineSeconds: 600
-  replicas: 1
   revisionHistoryLimit: 5
   selector:
     matchLabels:
       app: {{ template "submariner.fullname" . }}-engine
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxUnavailable: 1
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Currently, the Submariner Engine is a deployment with nodeSelector
(for submariner.io/gateway=true). It is seen that when the label
is removed from the node after SM engine is deployed, SM engine
continues to run on that node. This behavior is not in Sync with
the DaemonSet (used by GlobalnetController) behavior where the POD
is immediately terminated when the label is removed from the node.
This PR updates SM engine as DaemonSet so that we have consistent
behavior between the SM Engine POD and GlobalnetController POD.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>