### PR TITLE
Rename submariner engine daemonset to submariner-gateyway

### DIFF
--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.fullname" . }}-engine
     component: engine
-  name: {{ template "submariner.fullname" . }}
+  name: {{ template "submariner.fullname" . }}-gateway
 spec:
   revisionHistoryLimit: 5
   selector:


### PR DESCRIPTION
In previous upstream discussions we talked about renaming submariner
engine "deployment" (now daemonset) to submariner-gateway to make
identification of the gateway easier to admins and avoid confusion.

Also see: https://github.com/submariner-io/submariner-operator/pull/145