### PR TITLE
Make Gateway Leadership variables configurable

### DIFF
--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -100,6 +100,12 @@ spec:
           value: "{{ .Values.ipsec.ikePort }}"
         - name: CE_IPSEC_NATTPORT
           value: "{{ .Values.ipsec.natPort }}"
+        - name: LEADERSHIP_LEASEDURATION
+          value: "{{ .Values.leadership.leaseDuration }}"
+        - name: LEADERSHIP_RENEWDEADLINE
+          value: "{{ .Values.leadership.renewDeadline }}"
+        - name: LEADERSHIP_RETRYPERIOD
+          value: "{{ .Values.leadership.retryPeriod }}"
         image: {{ .Values.engine.image.repository }}:{{ .Values.engine.image.tag }}
         imagePullPolicy: {{ .Values.engine.image.pullPolicy }}
         name: submariner

--- a/submariner/values.yaml
+++ b/submariner/values.yaml
@@ -24,6 +24,10 @@ ipsec:
   debug: false
   ikePort: 500
   natPort: 4500
+leadership:
+  leaseDuration: 5
+  renewDeadline: 3
+  retryPeriod: 2
 engine:
   image:
     repository: rancher/submariner


### PR DESCRIPTION
This PR provides a mechanism to configure the following
Submariner Gateway leader election values
1. leaseDuration
2. renewDeadline
3. retryPeriod

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>