### PR TITLE
Add role for globalnet controller to annotate a node

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -69,11 +69,8 @@ metadata:
   name: {{ template "submariner.fullname" . }}:globalnet
 rules:
 - apiGroups: [""]
-  resources: ["services", "namespaces", "pods"]
+  resources: ["services", "namespaces", "pods", "nodes"]
   verbs: ["get", "list", "watch", "update"]
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get"]
 - apiGroups: ["submariner.io"]
   resources: ["endpoints", "clusters"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
As part of supporting connectivity from HostNetwork to remoteClusters, globalnet
controller annotates a node with globalIP. This PR adds the necessary roles for
globalnetController.

Fixes Issue: https://github.com/submariner-io/submariner-charts/issues/23

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>