### PR TITLE
Add ClusterRole for route-agent to annotate a node

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -62,6 +62,28 @@ subjects:
   name: {{ template "submariner.routeAgentServiceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "submariner.fullname" . }}:routeagent
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "submariner.fullname" . }}:routeagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "submariner.fullname" . }}:routeagent
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "submariner.routeAgentServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+---
 {{- if ne .Values.submariner.globalCidr "" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
As part of supporting connectivity from HostNetwork to remoteClusters, globalnet
controller requires the CNIInterfaceIP on each node. This PR adds the necessary
clusterRoles for the route-agent daemonSet which will annotate the node with the
CNIInterfaceIP on that respective node.

Fixes Issue: https://github.com/submariner-io/submariner-charts/issues/22

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>