### PR TITLE
Fix lighthouseServiceAccountName

### DIFF
--- a/submariner/templates/_helpers.tpl
+++ b/submariner/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Create the name of the submariner-globalnet service account to use
 Create the name of the submariner-lighthouse service account to use
 */}}
 {{- define "submariner.lighthouseServiceAccountName" -}}
-{{- if .Values.submariner.serviceDiscovery }}
+{{- if .Values.submariner.serviceDiscovery -}}
     {{ default (printf "%s-lighthouse" (include "submariner.fullname" .)) .Values.serviceAccounts.lighthouse.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccounts.lighthouse.name }}


### PR DESCRIPTION
It was missing the post-deletion operator which caused it to generate:
    name:
    submariner-lighthouse

Instead of `name: submariner-lighthouse`

Now it should be fine