### PR TITLE
Use v1beta1 for lighthouse CRDs

### DIFF
--- a/submariner-k8s-broker/templates/crd.yaml
+++ b/submariner-k8s-broker/templates/crd.yaml
@@ -58,7 +58,7 @@ spec:
                 port:
                   type: "integer"
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceexports.lighthouse.submariner.io

--- a/submariner/templates/crd.yaml
+++ b/submariner/templates/crd.yaml
@@ -77,7 +77,7 @@ spec:
                 port:
                   type: "integer"
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: serviceexports.lighthouse.submariner.io


### PR DESCRIPTION
v1 is only available k8s v1.16 onwards and we're using 1.14 in E2E.