### PR TITLE
Fix terminationGracePeriodSeconds in Submariner Pods

### DIFF
--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -130,5 +130,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "submariner.engineServiceAccountName" . }}

--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -21,6 +21,7 @@ spec:
       hostNetwork: true
       serviceAccountName: submariner-globalnet
       serviceAccount: submariner-globalnet
+      terminationGracePeriodSeconds: 10
       nodeSelector:
         submariner.io/gateway: 'true'
       containers:
@@ -31,7 +32,7 @@ spec:
             - name: SUBMARINER_CLUSTERID
               value: '{{ .Values.submariner.clusterId }}'
             - name: SUBMARINER_EXCLUDENS
-              value: 'submariner,kube-system,operators'
+              value: 'submariner-operator,kube-system,operators'
             - name: SUBMARINER_NAMESPACE
               value: '{{ .Release.Namespace }}'
           securityContext:

--- a/submariner/templates/route-agent-ds.yaml
+++ b/submariner/templates/route-agent-ds.yaml
@@ -22,7 +22,7 @@ spec:
         component: routeagent
     spec:
       serviceAccountName: {{ template "submariner.routeAgentServiceAccountName" . }}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 10
       hostNetwork: true
       containers:
       - name: routeagent


### PR DESCRIPTION
In K8s the default termination grace period for a Pod is 30
secs. However, for Globalnet, we were configuring this as
0 secs, because of which, cleanup was not happening in a
consistent manner and we are seeing failures in CI jobs.

This PR modifies the terminationGracePeriodSeconds to 10 secs.

Along with this change, it also uses the proper namespace of
submariner in the excluded namespaces.

Fixes issue: https://github.com/submariner-io/submariner-charts/issues/39

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>