### PR TITLE
Reset terminationGracePeriodSeconds for SM Pods

### DIFF
--- a/submariner/templates/engine-deploy.yaml
+++ b/submariner/templates/engine-deploy.yaml
@@ -130,5 +130,5 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 1
       serviceAccountName: {{ template "submariner.engineServiceAccountName" . }}

--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -25,7 +25,7 @@ spec:
       hostNetwork: true
       serviceAccountName: submariner-globalnet
       serviceAccount: submariner-globalnet
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 2
       nodeSelector:
         submariner.io/gateway: 'true'
       containers:

--- a/submariner/templates/route-agent-ds.yaml
+++ b/submariner/templates/route-agent-ds.yaml
@@ -26,7 +26,7 @@ spec:
         component: routeagent
     spec:
       serviceAccountName: {{ template "submariner.routeAgentServiceAccountName" . }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 1
       hostNetwork: true
       containers:
       - name: routeagent


### PR DESCRIPTION
In one of the earlier PRs, we modified the terminationGracePeriodSeconds
to 10 secs. However, its seen that this is causing more CI failures
during e2e redundancy tests. Ideally, once the Pods are terminated,
it should cleanup itself ASAP but it is seen that SM Pods are sometimes
taking time to exit and during this Period since there is no active SM
Pod running, this is triggering some failures.

Until we figure out the exact reason why the Pods are taking time for
cleanup, this PR reduces the terminationGracePeriodSeconds.

This issue would be properly addressed via
https://github.com/submariner-io/submariner/issues/694

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>