### PR TITLE
Allow lighthouse access to gateways.submariner.io

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -123,6 +123,9 @@ rules:
   - apiGroups: ["lighthouse.submariner.io"]
     resources: ["*"]
     verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["submariner.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Adds following permissions to lighthouse clusterrole
for `gateways.submariner.io`
 - get
 - list
 - watch

This allows lighthouse to track changes to gateway status and know which
clusters are connected.

Fixes https://github.com/submariner-io/lighthouse/issues/113

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>