### PR TITLE
Install gateway CRD on broker

### DIFF
--- a/submariner-k8s-broker/templates/crd.yaml
+++ b/submariner-k8s-broker/templates/crd.yaml
@@ -27,6 +27,25 @@ spec:
     plural: endpoints
   scope: Namespaced
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.submariner.io
+  annotations:
+    "helm.sh/hook": crd-install
+spec:
+  group: submariner.io
+  version: v1
+  names:
+    kind: Gateway
+    plural: gateways
+  scope: Namespaced
+  additionalPrinterColumns:
+    - name: ha-status
+      type: string
+      description: High Availability Status of the Gateway
+      JSONPath: .status.haStatus
+---
 {{- if .Values.submariner.serviceDiscovery }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
If crd.create is set to false when installing submariner on same cluster
as broker, gateways CRD never gets installed because it is missing from
broker charts. This change is to install the CRD even on broker, as a
cleaner alternative to adding more flags.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>