### PR TITLE
Modify updateStrategy for Route-agent Pods

### DIFF
--- a/submariner/templates/route-agent-ds.yaml
+++ b/submariner/templates/route-agent-ds.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ template "submariner.fullname" . }}-routeagent
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 1
+      maxUnavailable: "100%"
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
Currently, the updateStrategy for Route-agent pods is set to RollingUpdate
with maxUnavailable as 1. Because of this, when the route-agent DaemonSet
is updated, the Pods are updated one after the other. While the rolling
update strategy is good for user-facing services, for route-agent DaemonSet
its not the most suitable one as it takes time for all the route-agent pods
to be updated in a large cluster.

Ideally, it would have been great if "Recreate" updateStrategy was supported
for DaemonSets, but unfortunately K8s does not support it. But an alternate
way to achieve something similar is to configure rollingUpdate.maxUnavailable
to 100% so that the DaemonSet controller can update all the route-agent Pods
in a single go.

https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy

Fixes issue: https://github.com/submariner-io/submariner/issues/734

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>