### PR TITLE
Rename "supercluster" to "clusterset"

### DIFF
--- a/submariner/templates/lighthouse-coredns.yaml
+++ b/submariner/templates/lighthouse-coredns.yaml
@@ -62,7 +62,7 @@ metadata:
   name: {{ template "submariner.lighthouseDnsName" . }}
 data:
   Corefile: |
-    supercluster.local:53 {
+    clusterset.local:53 {
 {{- if .Values.submariner.debug }}
         log
 {{- end }}


### PR DESCRIPTION
The latter is the name chosen by the multi-cluster SIG.

Signed-off-by: Stephen Kitt <skitt@redhat.com>