### PR TITLE
Migrate CRDs to apiextensions v1

### DIFF
--- a/submariner-k8s-broker/templates/crd.yaml
+++ b/submariner-k8s-broker/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create -}}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.submariner.io
@@ -13,7 +13,7 @@ spec:
     plural: clusters
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: endpoints.submariner.io
@@ -27,7 +27,7 @@ spec:
     plural: endpoints
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.submariner.io
@@ -47,7 +47,7 @@ spec:
       JSONPath: .status.haStatus
 ---
 {{- if .Values.submariner.serviceDiscovery }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: multiclusterservices.lighthouse.submariner.io
@@ -77,7 +77,7 @@ spec:
                 port:
                   type: "integer"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceexports.lighthouse.submariner.io
@@ -92,7 +92,7 @@ spec:
     singular: serviceexport
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceimports.lighthouse.submariner.io

--- a/submariner/templates/crd.yaml
+++ b/submariner/templates/crd.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.crd.create -}}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.submariner.io
@@ -13,7 +13,7 @@ spec:
     plural: clusters
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: endpoints.submariner.io
@@ -27,7 +27,7 @@ spec:
     plural: endpoints
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.submariner.io
@@ -47,7 +47,7 @@ spec:
     JSONPath: .status.haStatus
 ---
 {{- if .Values.submariner.serviceDiscovery }}
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: multiclusterservices.lighthouse.submariner.io
@@ -77,7 +77,7 @@ spec:
                 port:
                   type: "integer"
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceexports.lighthouse.submariner.io
@@ -92,7 +92,7 @@ spec:
     singular: serviceexport
   scope: Namespaced
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceimports.lighthouse.submariner.io


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinition
is deprecated in Kubernetes v1.16 and will no longer be served in
v1.19. Use apiextensions.k8s.io/v1 instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>