### PR TITLE
Run YAML linting also via GHA

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,3 +43,15 @@ jobs:
         with:
           files: .
           config_file: ".markdownlint.yml"
+
+  yaml-lint:
+    name: YAML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v1
+        with:
+          file_or_dir: submariner/values.yaml submariner-k8s-broker/values.yaml submariner/Chart.yaml submariner-k8s-broker/Chart.yaml
+          config_file: .yamllint.yml


### PR DESCRIPTION
 YAML linting currently runs on Travis. Convert to a GHA, to align with other repos and prepare for future optimizations.
    
Only run against values.yaml and Chart.yaml files, as is currently the case in the Travis-driven workflow.