### PR TITLE
Exclude openshift-monitoring namespace in Globalnet

### DIFF
--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -36,7 +36,7 @@ spec:
             - name: SUBMARINER_CLUSTERID
               value: '{{ .Values.submariner.clusterId }}'
             - name: SUBMARINER_EXCLUDENS
-              value: 'submariner-operator,kube-system,operators,openshift-monitoring'
+              value: 'submariner-operator,kube-system,operators,openshift-monitoring,openshift-dns'
             - name: SUBMARINER_NAMESPACE
               value: '{{ .Release.Namespace }}'
           securityContext:

--- a/submariner/templates/globalnet.yaml
+++ b/submariner/templates/globalnet.yaml
@@ -36,7 +36,7 @@ spec:
             - name: SUBMARINER_CLUSTERID
               value: '{{ .Values.submariner.clusterId }}'
             - name: SUBMARINER_EXCLUDENS
-              value: 'submariner-operator,kube-system,operators'
+              value: 'submariner-operator,kube-system,operators,openshift-monitoring'
             - name: SUBMARINER_NAMESPACE
               value: '{{ .Release.Namespace }}'
           securityContext:


### PR DESCRIPTION
In an OCP Cluster, openshift-monitoring namespace has couple of
services and these are controlled by their respective operators.
When Globalnet is deployed on OCP, it was seen that globalip
annotation added to such services are periodically getting
deleted by the operators, so Globalnet tries to re-add the
annotation and this goes on forever. This will cause Globalnet
to consume CPU unnecessarily and could affect user-experience
with Submariner Globalnet. We have plans to enhance Globalnet
to improve its scalability, but until then we can exclude
annotating services in openshift-monitoring namespace.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>