### PR TITLE
Check out the full history for chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
chart-releaser looks at the project history to determine whether a
chart changed, we mustn't limit the fetch depth.

Signed-off-by: Stephen Kitt <skitt@redhat.com>