### PR TITLE
Ensure we overwrite charts when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,13 @@ preload-images:
 		import_image quay.io/submariner/$${image}; \
 	done
 
-$(CHARTS_DIR):
-	mkdir -p $(CHARTS_DIR)
-
-$(CHARTS_DIR)/%: $(CHARTS_DIR)
+%.tgz:
 	helm dep update $(subst -$(CHARTS_VERSION),,$(basename $(@F)))
 	helm package --version $(CHARTS_VERSION) $(subst -$(CHARTS_VERSION),,$(basename $(@F)))
-	mv -f $(@F) $@
 
-release: $(CHARTS_DIR)/submariner-$(CHARTS_VERSION).tgz $(CHARTS_DIR)/submariner-k8s-broker-$(CHARTS_VERSION).tgz $(CHARTS_DIR)/submariner-operator-$(CHARTS_VERSION).tgz
+release: submariner-$(CHARTS_VERSION).tgz submariner-k8s-broker-$(CHARTS_VERSION).tgz submariner-operator-$(CHARTS_VERSION).tgz
 	git checkout gh-pages
+	mv *.tgz $(CHARTS_DIR)
 	if [ -f $(CHARTS_DIR)/index.yaml ]; then \
 	  helm repo index $(CHARTS_DIR) --url $(GH_URL) --merge $(CHARTS_DIR)/index.yaml; \
 	else \


### PR DESCRIPTION
Currently, we lose updated charts when we check the gh-pages branch
out. This patch generates the charts in the base directory, and moves
them into place after checking the target branch out.

Signed-off-by: Stephen Kitt <skitt@redhat.com>