### PR TITLE
Include ClusterRole for routeagent to list nodes

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -69,7 +69,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "update"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
In the new event framework we use node listeners to support certain use-cases.
Currently in helm, routeagent does not have that role, so e2e tests are failing.
This PR enables it.

Related to: https://github.com/submariner-io/submariner/issues/858
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>