### PR TITLE
Add cable driver to E2E matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cable_driver: ['libreswan', 'wireguard']
         globalnet: ['', 'globalnet']
     steps:
       - name: Check out the repository
@@ -20,6 +21,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
+          cabledriver: ${{ matrix.cable_driver }}
           globalnet: ${{ matrix.globalnet }}
 
       - name: Post mortem


### PR DESCRIPTION
Run E2E tests with all cable drivers and with/without globalnet.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>