### PR TITLE
Add a cluster role for submariner-engine serivce-account

### DIFF
--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -119,7 +119,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "list", "watch", "update"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/submariner/templates/rbac.yaml
+++ b/submariner/templates/rbac.yaml
@@ -111,6 +111,30 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 {{- end -}}
+{{- if ne .Values.submariner.globalCidr "" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "submariner.fullname" . }}:engine
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "submariner.fullname" . }}:engine
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "submariner.fullname" . }}:engine
+subjects:
+- kind: ServiceAccount
+  name: {{ template "submariner.engineServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+{{- end -}}
 {{- if .Values.submariner.serviceDiscovery }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
The submainer-engine now access the node object as part
of golbalnet-healthcheck support and the required roles are
added

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>