### PR TITLE
Use markdownlint from Shipyard

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,10 +40,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
       - name: Run markdownlint
-        uses: nosborn/github-action-markdown-cli@v1.1.1
-        with:
-          files: .
-          config_file: ".markdownlint.yml"
+        run: make markdownlint
 
   yaml-lint:
     name: YAML


### PR DESCRIPTION
Instead of an external GitHub action, use the same markdownlint make
target from Shipyard that we use in other repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>