### PR TITLE
Add .dapper and .shflags to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.dapper
 .idea
+.shflags
 *.tgz


### PR DESCRIPTION
Both are generated by our standard make commands, both are ignored in
other Submariner repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>