### PR TITLE
Add flake finder periodic E2E tests

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -1,0 +1,30 @@
+---
+name: Flake Finder
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  e2e:
+    name: E2E
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cable_driver: ['libreswan', 'wireguard']
+        globalnet: ['', 'globalnet']
+        lighthouse: ['', 'lighthouse']
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run E2E deployment and tests
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          using: ${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}
+
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel


### PR DESCRIPTION
Periodically run E2E tests against the merged (must have passed E2E
gating) code to detect breakages due to external changes or flaky
failures.

Also supports debugging Helm-related failures in other repositories, by
verifying (or not) what's passing here.

Use the same test matrix as the current E2E job.

Mirrors similar tests in other Submariner repositories.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>