### PR TITLE
Split E2E into default and full

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,0 +1,37 @@
+---
+name: End to End Full
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  e2e:
+    name: E2E
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-test')
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cable_driver: ['libreswan', 'wireguard', 'vxlan']
+        globalnet: ['', 'globalnet']
+        k8s_version: ['1.17']
+        lighthouse: ['', 'lighthouse']
+        include:
+          - k8s_version: '1.18'
+          - k8s_version: '1.19'
+          - k8s_version: '1.20'
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run E2E deployment and tests
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+          using: ${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}
+
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 ---
-name: End to End Tests
+name: End to End Default
 
 on:
   pull_request:
@@ -9,26 +9,12 @@ jobs:
     name: E2E
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        cable_driver: ['libreswan', 'wireguard', 'vxlan']
-        globalnet: ['', 'globalnet']
-        k8s_version: ['1.17']
-        lighthouse: ['', 'lighthouse']
-        include:
-          - k8s_version: '1.18'
-          - k8s_version: '1.19'
-          - k8s_version: '1.20'
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
 
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
-        with:
-          k8s_version: ${{ matrix.k8s_version }}
-          using: ${{ matrix.cable_driver }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }}
 
       - name: Post mortem
         if: failure()


### PR DESCRIPTION
Following the pattern from other repos, split the E2E test job into a
default job that runs a single default-only test always on PRs and a
full job that runs the full matrix when the ready-to-test label is
added.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
