### PR TITLE
Release 0.9 backports

### DIFF
--- a/submariner-k8s-broker/Chart.yaml
+++ b/submariner-k8s-broker/Chart.yaml
@@ -1,6 +1,7 @@
 ---
 name: submariner-k8s-broker
 version: 0.6.0
+apiVersion: v2
 appVersion: 0.6.0
 description: Submariner Kubernetes Broker
 keywords:

--- a/submariner-k8s-broker/templates/rbac.yaml
+++ b/submariner-k8s-broker/templates/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "submariner-k8s-broker.fullname" . }}:client
+  name: {{ template "submariner-k8s-broker.fullname" . }}-cluster
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
@@ -25,11 +25,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "submariner-k8s-broker.fullname" . }}:client
+  name: {{ template "submariner-k8s-broker.fullname" . }}-cluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "submariner-k8s-broker.fullname" . }}:client
+  name: {{ template "submariner-k8s-broker.fullname" . }}-cluster
 subjects:
 - kind: ServiceAccount
   name: {{ template "submariner-k8s-broker.clientServiceAccountName" . }}

--- a/submariner-operator/Chart.yaml
+++ b/submariner-operator/Chart.yaml
@@ -1,6 +1,7 @@
 ---
 name: submariner-operator
 version: 0.7.0
+apiVersion: v2
 appVersion: 0.7.0
 description: Submariner enables direct networking between Pods and Services in different Kubernetes clusters
 keywords:

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -397,6 +397,7 @@ rules:
     resources:
       - configmaps
     verbs:
+      - create
       - get
       - list
       - watch
@@ -411,11 +412,13 @@ rules:
       - create
       - update
       - delete
-  - apiGroups:  # pods and services are looked up to figure out network settings
+      - watch
+  - apiGroups:  # pods, services and nodes are looked up to figure out network settings
       - ""
     resources:
       - pods
       - services
+      - nodes
     verbs:
       - get
       - list


### PR DESCRIPTION
Missing bits for the release-0.9 branch before v0.9.1 release:

* c9e268a fix(rbac): add missing cluster roles to submariner-operator … 
* 3cb11fd Add required apiVersion field to Chart.yaml …
* f1b2327 Name RBAC fields to match K8s requirements …

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
