### PR TITLE
Allow submariner-globalnet role to handle endpoints

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -643,6 +643,7 @@ rules:
       - services
       - namespaces
       - nodes
+      - endpoints
     verbs:
       - get
       - list


### PR DESCRIPTION
This PR allows submariner-globalnet role to handle endpoints. This is needed to make globalnet controller support headless service without selector.

xref: submariner-io/submariner#1558
fixes: #168