### PR TITLE
Automated backport of #176: Add RBAC permission endpointslices/restricted in broker roles

### DIFF
--- a/submariner-k8s-broker/templates/rbac.yaml
+++ b/submariner-k8s-broker/templates/rbac.yaml
@@ -16,7 +16,7 @@ rules:
   resources: ["*"]
   verbs: ["create", "get", "list", "watch", "patch", "update", "delete"]
 - apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
+  resources: ["endpointslices", "endpointslices/restricted"]
   verbs: ["create", "get", "list", "watch","patch", "update", "delete"]
 - apiGroups: ["multicluster.x-k8s.io"]
   resources: ["*"]


### PR DESCRIPTION
Backport of #176 on release-0.11.

#176: Add RBAC permission endpointslices/restricted in broker roles

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.