### PR TITLE
Fix connectionHealthCheck

### DIFF
--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -26,7 +26,10 @@ spec:
   globalCIDR: "{{ .Values.submariner.globalCidr }}"
   serviceDiscoveryEnabled: {{ .Values.submariner.serviceDiscovery }}
   cableDriver: {{ .Values.submariner.cableDriver }}
-  connectionHealthCheck: {{ .Values.submariner.healthcheckEnabled }}
+  connectionHealthCheck:
+    enabled: {{ .Values.submariner.healthcheckEnabled }}
+    intervalSeconds: 1
+    maxPacketLossCount: 5
 {{- with .Values.submariner.coreDNSCustomConfig }}
   coreDNSCustomConfig:
     configmapName: .configmapName


### PR DESCRIPTION
connectionHealthCheck in submariner CR is a nested field
but is being added as a variable. This means it is ignored
and the field isn't set correctly in gateway pods.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>