### PR TITLE
Automated backport of #179: Fix connectionHealthCheck

### DIFF
--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -26,7 +26,10 @@ spec:
   globalCIDR: "{{ .Values.submariner.globalCidr }}"
   serviceDiscoveryEnabled: {{ .Values.submariner.serviceDiscovery }}
   cableDriver: {{ .Values.submariner.cableDriver }}
-  connectionHealthCheck: {{ .Values.submariner.healthcheckEnabled }}
+  connectionHealthCheck:
+    enabled: {{ .Values.submariner.healthcheckEnabled }}
+    intervalSeconds: 1
+    maxPacketLossCount: 5
 {{- with .Values.submariner.coreDNSCustomConfig }}
   coreDNSCustomConfig:
     configmapName: .configmapName


### PR DESCRIPTION
Backport of #179 on release-0.11.

#179: Fix connectionHealthCheck

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.