### PR TITLE
Change NATEnabled default from false to true

### DIFF
--- a/deploy_helm
+++ b/deploy_helm
@@ -61,7 +61,7 @@ function helm_install_subm() {
         --set serviceAccounts.globalnet.create="${globalnet}" \
         --set serviceAccounts.lighthouseAgent.create="${service_discovery}" \
         --set serviceAccounts.lighthouseCoreDns.create="${service_discovery}" \
-        --set submariner.natEnabled="false" \
+        --set submariner.natEnabled="true" \
         --set operator.image.repository="localhost:5000/submariner-operator" \
         --set operator.image.tag="local" \
         --set operator.image.pullPolicy="IfNotPresent" \

--- a/submariner-operator/README.md
+++ b/submariner-operator/README.md
@@ -65,7 +65,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 | submariner.healthcheckEnabled | bool | `true` |  |
 | submariner.images.repository | string | `"quay.io/submariner"` |  |
 | submariner.images.tag | string | `"0.10.1"` |  |
-| submariner.natEnabled | bool | `false` |  |
+| submariner.natEnabled | bool | `true` |  |
 | submariner.serviceCidr | string | `""` |  |
 | submariner.serviceDiscovery | bool | `true` |  |
 | submariner.token | string | `""` |  |

--- a/submariner-operator/questions.yml
+++ b/submariner-operator/questions.yml
@@ -114,9 +114,9 @@ questions:
     required: false
 - variable: submariner.natEnabled
   type: boolean
-  default: false
+  default: true
   group: "Advanced Configuration"
-  description: "If the gateway nodes for this cluster are behind 1:1 NAT, you should enable NAT"
+  description: "If the gateway nodes for this cluster are behind 1:1 NAT, like in a public cloud, you should enable NAT"
   label: "NAT Enabled"
 - variable: submariner.debug
   type: boolean

--- a/submariner-operator/values.yaml
+++ b/submariner-operator/values.yaml
@@ -5,7 +5,7 @@ submariner:
   clusterCidr: ""
   serviceCidr: ""
   globalCidr: ""
-  natEnabled: false
+  natEnabled: true
   colorCodes: blue
   debug: false
   serviceDiscovery: true


### PR DESCRIPTION
Matches the values used in the following locations.

Helm installs in CI:

scripts/shared/lib/deploy_helm:61

Operator controller tests:

controllers/submariner/submariner_controller_test.go:428

Bundle install example:

bundle/manifests/submariner.clusterserviceversion.yaml#L49

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
