### PR TITLE
Backport all necessary fixes to the 0.11 branch

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.19']
+        k8s_version: ['1.23']
         lighthouse: ['', 'lighthouse']
         include:
           - k8s_version: '1.20'

--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -16,12 +16,12 @@ jobs:
       matrix:
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.17']
+        k8s_version: ['1.19']
         lighthouse: ['', 'lighthouse']
         include:
-          - k8s_version: '1.18'
-          - k8s_version: '1.19'
           - k8s_version: '1.20'
+          - k8s_version: '1.21'
+          - k8s_version: '1.22'
     steps:
       - name: Check out the repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
+# Auto-generated, do not edit; see CODEOWNERS.in
 * @Oats87 @skitt @sridhargaddam @tpantelis
+*.md @dfarrell07 @Oats87 @skitt @sridhargaddam @tpantelis

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mangelajo @Oats87 @skitt @sridhargaddam @tpantelis
+* @Oats87 @skitt @sridhargaddam @tpantelis

--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,0 +1,5 @@
+@dfarrell07 *.md
+@Oats87 *
+@skitt *
+@sridhargaddam *
+@tpantelis *

--- a/submariner-k8s-broker/crds/crd.yaml
+++ b/submariner-k8s-broker/crds/crd.yaml
@@ -1,97 +1,333 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.submariner.io
 spec:
   group: submariner.io
-  version: v1
   names:
     kind: Cluster
+    listKind: ClusterList
     plural: clusters
+    singular: cluster
   scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              cluster_cidr:
+                items:
+                  type: string
+                type: array
+              cluster_id:
+                type: string
+              color_codes:
+                items:
+                  type: string
+                type: array
+              global_cidr:
+                items:
+                  type: string
+                type: array
+              service_cidr:
+                items:
+                  type: string
+                type: array
+            required:
+            - cluster_cidr
+            - cluster_id
+            - color_codes
+            - global_cidr
+            - service_cidr
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: endpoints.submariner.io
 spec:
   group: submariner.io
-  version: v1
   names:
     kind: Endpoint
+    listKind: EndpointList
     plural: endpoints
+    singular: endpoint
   scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              backend:
+                type: string
+              backend_config:
+                additionalProperties:
+                  type: string
+                type: object
+              cable_name:
+                type: string
+              cluster_id:
+                type: string
+              healthCheckIP:
+                type: string
+              hostname:
+                type: string
+              nat_enabled:
+                type: boolean
+              private_ip:
+                type: string
+              public_ip:
+                type: string
+              subnets:
+                items:
+                  type: string
+                type: array
+            required:
+            - backend
+            - cable_name
+            - cluster_id
+            - hostname
+            - nat_enabled
+            - private_ip
+            - public_ip
+            - subnets
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gateways.submariner.io
 spec:
   group: submariner.io
-  version: v1
   names:
     kind: Gateway
+    listKind: GatewayList
     plural: gateways
+    singular: gateway
   scope: Namespaced
-  additionalPrinterColumns:
-    - name: ha-status
+  versions:
+  - additionalPrinterColumns:
+    - description: High availability status of the Gateway
+      jsonPath: .status.haStatus
+      name: HA Status
       type: string
-      description: High Availability Status of the Gateway
-      JSONPath: .status.haStatus
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: multiclusterservices.lighthouse.submariner.io
-spec:
-  group: lighthouse.submariner.io
-  version: v1
-  names:
-    kind: MultiClusterService
-    plural: multiclusterservices
-    singular: multiclusterservice
-  scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            clusterServiceInfo:
-              properties:
-                clusterID:
-                  type: "string"
-                clusterDomain:
-                  type: "string"
-                serviceIP:
-                  type: "string"
-                port:
-                  type: "integer"
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: serviceexports.lighthouse.submariner.io
-spec:
-  group: lighthouse.submariner.io
-  version: v2alpha1
-  names:
-    kind: ServiceExport
-    plural: serviceexports
-    singular: serviceexport
-  scope: Namespaced
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: serviceimports.lighthouse.submariner.io
-spec:
-  group: lighthouse.submariner.io
-  version: v2alpha1
-  names:
-    kind: ServiceImport
-    plural: serviceimports
-    singular: serviceimport
-  scope: Namespaced
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            properties:
+              connections:
+                items:
+                  properties:
+                    endpoint:
+                      properties:
+                        backend:
+                          type: string
+                        backend_config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cable_name:
+                          type: string
+                        cluster_id:
+                          type: string
+                        healthCheckIP:
+                          type: string
+                        hostname:
+                          type: string
+                        nat_enabled:
+                          type: boolean
+                        private_ip:
+                          type: string
+                        public_ip:
+                          type: string
+                        subnets:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - backend
+                      - cable_name
+                      - cluster_id
+                      - hostname
+                      - nat_enabled
+                      - private_ip
+                      - public_ip
+                      - subnets
+                      type: object
+                    latency:
+                      description: LatencySpec describes the round trip time information
+                        in nanoseconds for a packet between the gateway pods of two
+                        clusters.
+                      properties:
+                        averageRTT:
+                          format: int64
+                          type: integer
+                        lastRTT:
+                          description: TODO This shall be deleted once the operator
+                            is using the latest. Using Optional to avoid validation
+                            errors when this field is not used.
+                          format: int64
+                          type: integer
+                        maxRTT:
+                          format: int64
+                          type: integer
+                        minRTT:
+                          format: int64
+                          type: integer
+                        stddevRTT:
+                          format: int64
+                          type: integer
+                      type: object
+                    latencyRTT:
+                      description: LatencySpec describes the round trip time information
+                        for a packet between the gateway pods of two clusters.
+                      properties:
+                        average:
+                          type: string
+                        last:
+                          type: string
+                        max:
+                          type: string
+                        min:
+                          type: string
+                        stdDev:
+                          type: string
+                      type: object
+                    status:
+                      type: string
+                    statusMessage:
+                      type: string
+                  required:
+                  - endpoint
+                  - status
+                  - statusMessage
+                  type: object
+                type: array
+              haStatus:
+                type: string
+              localEndpoint:
+                properties:
+                  backend:
+                    type: string
+                  backend_config:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  cable_name:
+                    type: string
+                  cluster_id:
+                    type: string
+                  healthCheckIP:
+                    type: string
+                  hostname:
+                    type: string
+                  nat_enabled:
+                    type: boolean
+                  private_ip:
+                    type: string
+                  public_ip:
+                    type: string
+                  subnets:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - backend
+                - cable_name
+                - cluster_id
+                - hostname
+                - nat_enabled
+                - private_ip
+                - public_ip
+                - subnets
+                type: object
+              statusFailure:
+                type: string
+              version:
+                type: string
+            required:
+            - connections
+            - haStatus
+            - localEndpoint
+            - statusFailure
+            - version
+            type: object
+        required:
+        - status
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/submariner-operator/crds/crd.yaml
+++ b/submariner-operator/crds/crd.yaml
@@ -1,10 +1,11 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: submariners.submariner.io
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: submariners.submariner.io
 spec:
   group: submariner.io
   names:
@@ -13,707 +14,812 @@ spec:
     plural: submariners
     singular: submariner
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Submariner is the Schema for the submariners API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: SubmarinerSpec defines the desired state of Submariner
-          properties:
-            broker:
-              type: string
-            brokerK8sApiServer:
-              type: string
-            brokerK8sApiServerToken:
-              type: string
-            brokerK8sCA:
-              type: string
-            brokerK8sRemoteNamespace:
-              type: string
-            cableDriver:
-              type: string
-            ceIPSecDebug:
-              type: boolean
-            ceIPSecIKEPort:
-              type: integer
-            ceIPSecNATTPort:
-              type: integer
-            ceIPSecPSK:
-              type: string
-            clusterCIDR:
-              type: string
-            clusterID:
-              type: string
-            colorCodes:
-              type: string
-            customDomains:
-              items:
-                type: string
-              type: array
-              x-kubernetes-list-type: set
-            debug:
-              type: boolean
-            globalCIDR:
-              type: string
-            namespace:
-              type: string
-            natEnabled:
-              type: boolean
-            repository:
-              type: string
-            serviceCIDR:
-              type: string
-            serviceDiscoveryEnabled:
-              type: boolean
-            version:
-              type: string
-          required:
-          - broker
-          - brokerK8sApiServer
-          - brokerK8sApiServerToken
-          - brokerK8sCA
-          - brokerK8sRemoteNamespace
-          - ceIPSecDebug
-          - ceIPSecPSK
-          - clusterCIDR
-          - clusterID
-          - debug
-          - namespace
-          - natEnabled
-          - serviceCIDR
-          type: object
-        status:
-          description: SubmarinerStatus defines the observed state of Submariner
-          properties:
-            clusterCIDR:
-              type: string
-            clusterID:
-              type: string
-            colorCodes:
-              type: string
-            gatewayDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            gateways:
-              items:
-                properties:
-                  connections:
-                    items:
-                      properties:
-                        endpoint:
-                          properties:
-                            backend:
-                              type: string
-                            backend_config:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            cable_name:
-                              type: string
-                            cluster_id:
-                              type: string
-                            hostname:
-                              type: string
-                            nat_enabled:
-                              type: boolean
-                            private_ip:
-                              type: string
-                            public_ip:
-                              type: string
-                            subnets:
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - backend
-                          - cable_name
-                          - cluster_id
-                          - hostname
-                          - nat_enabled
-                          - private_ip
-                          - public_ip
-                          - subnets
-                          type: object
-                        status:
-                          type: string
-                        statusMessage:
-                          type: string
-                      required:
-                      - endpoint
-                      - status
-                      - statusMessage
-                      type: object
-                    type: array
-                  haStatus:
-                    type: string
-                  localEndpoint:
-                    properties:
-                      backend:
-                        type: string
-                      backend_config:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      cable_name:
-                        type: string
-                      cluster_id:
-                        type: string
-                      hostname:
-                        type: string
-                      nat_enabled:
-                        type: boolean
-                      private_ip:
-                        type: string
-                      public_ip:
-                        type: string
-                      subnets:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - backend
-                    - cable_name
-                    - cluster_id
-                    - hostname
-                    - nat_enabled
-                    - private_ip
-                    - public_ip
-                    - subnets
-                    type: object
-                  statusFailure:
-                    type: string
-                  version:
-                    type: string
-                required:
-                - connections
-                - haStatus
-                - localEndpoint
-                - statusFailure
-                - version
-                type: object
-              type: array
-            globalCIDR:
-              type: string
-            globalnetDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            natEnabled:
-              type: boolean
-            routeAgentDaemonSetStatus:
-              properties:
-                lastResourceVersion:
-                  type: string
-                mismatchedContainerImages:
-                  type: boolean
-                nonReadyContainerStates:
-                  items:
-                    description: ContainerState holds a possible state of container.
-                      Only one of its members may be specified. If none of them is
-                      specified, the default one is ContainerStateWaiting.
-                    properties:
-                      running:
-                        description: Details about a running container
-                        properties:
-                          startedAt:
-                            description: Time at which the container was last (re-)started
-                            format: date-time
-                            type: string
-                        type: object
-                      terminated:
-                        description: Details about a terminated container
-                        properties:
-                          containerID:
-                            description: Container's ID in the format 'docker://<container_id>'
-                            type: string
-                          exitCode:
-                            description: Exit status from the last termination of
-                              the container
-                            format: int32
-                            type: integer
-                          finishedAt:
-                            description: Time at which the container last terminated
-                            format: date-time
-                            type: string
-                          message:
-                            description: Message regarding the last termination of
-                              the container
-                            type: string
-                          reason:
-                            description: (brief) reason from the last termination
-                              of the container
-                            type: string
-                          signal:
-                            description: Signal from the last termination of the container
-                            format: int32
-                            type: integer
-                          startedAt:
-                            description: Time at which previous execution of the container
-                              started
-                            format: date-time
-                            type: string
-                        required:
-                        - exitCode
-                        type: object
-                      waiting:
-                        description: Details about a waiting container
-                        properties:
-                          message:
-                            description: Message regarding why the container is not
-                              yet running.
-                            type: string
-                          reason:
-                            description: (brief) reason the container is not yet running.
-                            type: string
-                        type: object
-                    type: object
-                  type: array
-                status:
-                  description: DaemonSetStatus represents the current status of a
-                    daemon set.
-                  properties:
-                    collisionCount:
-                      description: Count of hash collisions for the DaemonSet. The
-                        DaemonSet controller uses this field as a collision avoidance
-                        mechanism when it needs to create the name for the newest
-                        ControllerRevision.
-                      format: int32
-                      type: integer
-                    conditions:
-                      description: Represents the latest available observations of
-                        a DaemonSet's current state.
-                      items:
-                        description: DaemonSetCondition describes the state of a DaemonSet
-                          at a certain point.
-                        properties:
-                          lastTransitionTime:
-                            description: Last time the condition transitioned from
-                              one status to another.
-                            format: date-time
-                            type: string
-                          message:
-                            description: A human readable message indicating details
-                              about the transition.
-                            type: string
-                          reason:
-                            description: The reason for the condition's last transition.
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            type: string
-                          type:
-                            description: Type of DaemonSet condition.
-                            type: string
-                        required:
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    currentNumberScheduled:
-                      description: 'The number of nodes that are running at least
-                        1 daemon pod and are supposed to run the daemon pod. More
-                        info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    desiredNumberScheduled:
-                      description: 'The total number of nodes that should be running
-                        the daemon pod (including nodes correctly running the daemon
-                        pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberAvailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and available (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    numberMisscheduled:
-                      description: 'The number of nodes that are running the daemon
-                        pod, but are not supposed to run the daemon pod. More info:
-                        https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
-                      format: int32
-                      type: integer
-                    numberReady:
-                      description: The number of nodes that should be running the
-                        daemon pod and have one or more of the daemon pod running
-                        and ready.
-                      format: int32
-                      type: integer
-                    numberUnavailable:
-                      description: The number of nodes that should be running the
-                        daemon pod and have none of the daemon pod running and available
-                        (ready for at least spec.minReadySeconds)
-                      format: int32
-                      type: integer
-                    observedGeneration:
-                      description: The most recent generation observed by the daemon
-                        set controller.
-                      format: int64
-                      type: integer
-                    updatedNumberScheduled:
-                      description: The total number of nodes that are running updated
-                        daemon pod
-                      format: int32
-                      type: integer
-                  required:
-                  - currentNumberScheduled
-                  - desiredNumberScheduled
-                  - numberMisscheduled
-                  - numberReady
-                  type: object
-              required:
-              - mismatchedContainerImages
-              type: object
-            serviceCIDR:
-              type: string
-          required:
-          - clusterID
-          - natEnabled
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Submariner is the Schema for the submariners API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SubmarinerSpec defines the desired state of Submariner
+            properties:
+              broker:
+                type: string
+              brokerK8sApiServer:
+                type: string
+              brokerK8sApiServerToken:
+                type: string
+              brokerK8sCA:
+                type: string
+              brokerK8sInsecure:
+                type: boolean
+              brokerK8sRemoteNamespace:
+                type: string
+              cableDriver:
+                type: string
+              ceIPSecDebug:
+                type: boolean
+              ceIPSecForceUDPEncaps:
+                type: boolean
+              ceIPSecIKEPort:
+                type: integer
+              ceIPSecNATTPort:
+                type: integer
+              ceIPSecPSK:
+                type: string
+              ceIPSecPreferredServer:
+                type: boolean
+              clusterCIDR:
+                type: string
+              clusterID:
+                type: string
+              colorCodes:
+                type: string
+              connectionHealthCheck:
+                properties:
+                  enabled:
+                    type: boolean
+                  intervalSeconds:
+                    description: The interval at which health check pings are sent.
+                    format: int64
+                    type: integer
+                  maxPacketLossCount:
+                    description: The maximum number of packets lost at which the health
+                      checker will mark the connection as down.
+                    format: int64
+                    type: integer
+                type: object
+              coreDNSCustomConfig:
+                properties:
+                  configMapName:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              customDomains:
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              debug:
+                type: boolean
+              globalCIDR:
+                type: string
+              imageOverrides:
+                additionalProperties:
+                  type: string
+                type: object
+              loadBalancerEnabled:
+                type: boolean
+              namespace:
+                type: string
+              natEnabled:
+                type: boolean
+              repository:
+                type: string
+              serviceCIDR:
+                type: string
+              serviceDiscoveryEnabled:
+                type: boolean
+              version:
+                type: string
+            required:
+            - broker
+            - brokerK8sApiServer
+            - brokerK8sApiServerToken
+            - brokerK8sCA
+            - brokerK8sRemoteNamespace
+            - ceIPSecDebug
+            - ceIPSecPSK
+            - clusterCIDR
+            - clusterID
+            - debug
+            - namespace
+            - natEnabled
+            - serviceCIDR
+            type: object
+          status:
+            description: SubmarinerStatus defines the observed state of Submariner
+            properties:
+              clusterCIDR:
+                type: string
+              clusterID:
+                type: string
+              colorCodes:
+                type: string
+              deploymentInfo:
+                properties:
+                  cloudProvider:
+                    type: string
+                  kubernetesType:
+                    type: string
+                  kubernetesTypeVersion:
+                    type: string
+                  kubernetesVersion:
+                    type: string
+                type: object
+              gatewayDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              gateways:
+                items:
+                  properties:
+                    connections:
+                      items:
+                        properties:
+                          endpoint:
+                            properties:
+                              backend:
+                                type: string
+                              backend_config:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              cable_name:
+                                type: string
+                              cluster_id:
+                                maxLength: 63
+                                minLength: 1
+                                type: string
+                              healthCheckIP:
+                                type: string
+                              hostname:
+                                type: string
+                              nat_enabled:
+                                type: boolean
+                              private_ip:
+                                type: string
+                              public_ip:
+                                type: string
+                              subnets:
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - backend
+                            - cable_name
+                            - cluster_id
+                            - hostname
+                            - nat_enabled
+                            - private_ip
+                            - public_ip
+                            - subnets
+                            type: object
+                          latencyRTT:
+                            description: LatencySpec describes the round trip time
+                              information for a packet between the gateway pods of
+                              two clusters.
+                            properties:
+                              average:
+                                type: string
+                              last:
+                                type: string
+                              max:
+                                type: string
+                              min:
+                                type: string
+                              stdDev:
+                                type: string
+                            type: object
+                          status:
+                            type: string
+                          statusMessage:
+                            type: string
+                          usingIP:
+                            type: string
+                          usingNAT:
+                            type: boolean
+                        required:
+                        - endpoint
+                        - status
+                        - statusMessage
+                        type: object
+                      type: array
+                    haStatus:
+                      type: string
+                    localEndpoint:
+                      properties:
+                        backend:
+                          type: string
+                        backend_config:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cable_name:
+                          type: string
+                        cluster_id:
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                        healthCheckIP:
+                          type: string
+                        hostname:
+                          type: string
+                        nat_enabled:
+                          type: boolean
+                        private_ip:
+                          type: string
+                        public_ip:
+                          type: string
+                        subnets:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - backend
+                      - cable_name
+                      - cluster_id
+                      - hostname
+                      - nat_enabled
+                      - private_ip
+                      - public_ip
+                      - subnets
+                      type: object
+                    statusFailure:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - connections
+                  - haStatus
+                  - localEndpoint
+                  - statusFailure
+                  - version
+                  type: object
+                type: array
+              globalCIDR:
+                type: string
+              globalnetDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              loadBalancerStatus:
+                properties:
+                  status:
+                    description: LoadBalancerStatus represents the status of a load-balancer.
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              natEnabled:
+                type: boolean
+              networkPlugin:
+                type: string
+              routeAgentDaemonSetStatus:
+                properties:
+                  lastResourceVersion:
+                    type: string
+                  mismatchedContainerImages:
+                    type: boolean
+                  nonReadyContainerStates:
+                    items:
+                      description: ContainerState holds a possible state of container.
+                        Only one of its members may be specified. If none of them
+                        is specified, the default one is ContainerStateWaiting.
+                      properties:
+                        running:
+                          description: Details about a running container
+                          properties:
+                            startedAt:
+                              description: Time at which the container was last (re-)started
+                              format: date-time
+                              type: string
+                          type: object
+                        terminated:
+                          description: Details about a terminated container
+                          properties:
+                            containerID:
+                              description: Container's ID in the format 'docker://<container_id>'
+                              type: string
+                            exitCode:
+                              description: Exit status from the last termination of
+                                the container
+                              format: int32
+                              type: integer
+                            finishedAt:
+                              description: Time at which the container last terminated
+                              format: date-time
+                              type: string
+                            message:
+                              description: Message regarding the last termination
+                                of the container
+                              type: string
+                            reason:
+                              description: (brief) reason from the last termination
+                                of the container
+                              type: string
+                            signal:
+                              description: Signal from the last termination of the
+                                container
+                              format: int32
+                              type: integer
+                            startedAt:
+                              description: Time at which previous execution of the
+                                container started
+                              format: date-time
+                              type: string
+                          required:
+                          - exitCode
+                          type: object
+                        waiting:
+                          description: Details about a waiting container
+                          properties:
+                            message:
+                              description: Message regarding why the container is
+                                not yet running.
+                              type: string
+                            reason:
+                              description: (brief) reason the container is not yet
+                                running.
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  status:
+                    description: DaemonSetStatus represents the current status of
+                      a daemon set.
+                    properties:
+                      collisionCount:
+                        description: Count of hash collisions for the DaemonSet. The
+                          DaemonSet controller uses this field as a collision avoidance
+                          mechanism when it needs to create the name for the newest
+                          ControllerRevision.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Represents the latest available observations
+                          of a DaemonSet's current state.
+                        items:
+                          description: DaemonSetCondition describes the state of a
+                            DaemonSet at a certain point.
+                          properties:
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: A human readable message indicating details
+                                about the transition.
+                              type: string
+                            reason:
+                              description: The reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: Type of DaemonSet condition.
+                              type: string
+                          required:
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      currentNumberScheduled:
+                        description: 'The number of nodes that are running at least
+                          1 daemon pod and are supposed to run the daemon pod. More
+                          info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      desiredNumberScheduled:
+                        description: 'The total number of nodes that should be running
+                          the daemon pod (including nodes correctly running the daemon
+                          pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberAvailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and available (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      numberMisscheduled:
+                        description: 'The number of nodes that are running the daemon
+                          pod, but are not supposed to run the daemon pod. More info:
+                          https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/'
+                        format: int32
+                        type: integer
+                      numberReady:
+                        description: The number of nodes that should be running the
+                          daemon pod and have one or more of the daemon pod running
+                          and ready.
+                        format: int32
+                        type: integer
+                      numberUnavailable:
+                        description: The number of nodes that should be running the
+                          daemon pod and have none of the daemon pod running and available
+                          (ready for at least spec.minReadySeconds)
+                        format: int32
+                        type: integer
+                      observedGeneration:
+                        description: The most recent generation observed by the daemon
+                          set controller.
+                        format: int64
+                        type: integer
+                      updatedNumberScheduled:
+                        description: The total number of nodes that are running updated
+                          daemon pod
+                        format: int32
+                        type: integer
+                    required:
+                    - currentNumberScheduled
+                    - desiredNumberScheduled
+                    - numberMisscheduled
+                    - numberReady
+                    type: object
+                required:
+                - mismatchedContainerImages
+                type: object
+              serviceCIDR:
+                type: string
+            required:
+            - clusterID
+            - natEnabled
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
@@ -725,7 +831,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.4.1
   creationTimestamp: null
   name: servicediscoveries.submariner.io
 spec:
@@ -737,72 +843,93 @@ spec:
     singular: servicediscovery
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: ServiceDiscovery is the Schema for the servicediscoveries API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ServiceDiscovery is the Schema for the servicediscoveries API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ServiceDiscoverySpec defines the desired state of ServiceDiscovery
-              properties:
-                brokerK8sApiServer:
-                  type: string
-                brokerK8sApiServerToken:
-                  type: string
-                brokerK8sCA:
-                  type: string
-                brokerK8sRemoteNamespace:
-                  type: string
-                clusterID:
-                  type: string
-                customDomains:
-                  items:
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceDiscoverySpec defines the desired state of ServiceDiscovery
+            properties:
+              brokerK8sApiServer:
+                type: string
+              brokerK8sApiServerToken:
+                type: string
+              brokerK8sCA:
+                type: string
+              brokerK8sInsecure:
+                type: boolean
+              brokerK8sRemoteNamespace:
+                type: string
+              clusterID:
+                type: string
+              coreDNSCustomConfig:
+                properties:
+                  configMapName:
                     type: string
-                  type: array
-                  x-kubernetes-list-type: set
-                debug:
-                  type: boolean
-                globalnetEnabled:
-                  type: boolean
-                imageOverrides:
-                  additionalProperties:
+                  namespace:
                     type: string
-                  type: object
-                namespace:
+                type: object
+              customDomains:
+                items:
                   type: string
-                repository:
+                type: array
+                x-kubernetes-list-type: set
+              debug:
+                type: boolean
+              globalnetEnabled:
+                type: boolean
+              imageOverrides:
+                additionalProperties:
                   type: string
-                version:
-                  type: string
-              required:
-                - brokerK8sApiServer
-                - brokerK8sApiServerToken
-                - brokerK8sCA
-                - brokerK8sRemoteNamespace
-                - clusterID
-                - debug
-                - namespace
-              type: object
-            status:
-              description: ServiceDiscoveryStatus defines the observed state of ServiceDiscovery
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              namespace:
+                type: string
+              repository:
+                type: string
+              version:
+                type: string
+            required:
+            - brokerK8sApiServer
+            - brokerK8sApiServerToken
+            - brokerK8sCA
+            - brokerK8sRemoteNamespace
+            - clusterID
+            - debug
+            - namespace
+            type: object
+          status:
+            description: ServiceDiscoveryStatus defines the observed state of ServiceDiscovery
+            properties:
+              deploymentInfo:
+                properties:
+                  cloudProvider:
+                    type: string
+                  kubernetesType:
+                    type: string
+                  kubernetesTypeVersion:
+                    type: string
+                  kubernetesVersion:
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -643,6 +643,7 @@ rules:
       - services
       - namespaces
       - nodes
+      - endpoints
     verbs:
       - get
       - list

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -439,6 +439,21 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -457,6 +472,29 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "submariner.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: submariner-metrics-reader
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-submariner-metrics
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: submariner-metrics-reader
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -678,7 +678,6 @@ rules:
       - ""
     resources:
       - pods
-      - services
       - namespaces
       - nodes
       - endpoints
@@ -687,6 +686,17 @@ rules:
       - list
       - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
   - apiGroups:
       - submariner.io
     resources:

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -737,6 +737,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - network.openshift.io
+    resources:
+      - service/externalips
+    verbs:
+      - create
+      - get
+      - list
+      - delete
 ---
 {{- end -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -33,6 +33,6 @@ spec:
     maxPacketLossCount: 5
 {{- with .Values.submariner.coreDNSCustomConfig }}
   coreDNSCustomConfig:
-    configmapName: .configmapName
-    namespace: .namespace
+    configmapName: {{ .configmapName }}
+    namespace: {{ .namespace }}
 {{- end }}

--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -9,6 +9,7 @@ spec:
   brokerK8sApiServerToken: {{ .Values.broker.token }}
   brokerK8sCA: {{ .Values.broker.ca }}
   brokerK8sRemoteNamespace: {{ .Values.broker.namespace }}
+  brokerK8sInsecure: {{ .Values.broker.insecure }}
   ceIPSecDebug: {{ .Values.ipsec.debug }}
   ceIPSecForceUDPEncaps: {{ .Values.ipsec.forceUDPEncaps }}
   ceIPSecIKEPort: {{ .Values.ipsec.ikePort }}


### PR DESCRIPTION
This will fix current RBAC problems in particular. The 0.11 branch publishes the “latest” charts, so this is what users get by default.