### PR TITLE
Remove K8s 1.20 tests as it's EOL

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -19,7 +19,6 @@ jobs:
         k8s_version: ['1.23']
         lighthouse: ['', 'lighthouse']
         include:
-          - k8s_version: '1.20'
           - k8s_version: '1.21'
           - k8s_version: '1.22'
     steps:


### PR DESCRIPTION
Remove tests for Kubernetes 1.20, as it is End of Life and Submariner
supports all versions upstream-Kubernetes supports and no EOL versions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
