### PR TITLE
Fix link redirect, fixing MD link check CI

### DIFF
--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -1,6 +1,9 @@
 {
   "ignorePatterns": [
     {
+      "pattern": "^https://docs.github.com"
+    },
+    {
       "pattern": "^https://github.com/\\S+/\\S+/(issues|pull)/[0-9]+"
     },
     {

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ working correctly.
 [Helm]: https://helm.sh/docs/using_helm/#installing-helm
 [Docker]: https://docs.docker.com/install/
 [Podman]: https://podman.io/getting-started/installation
-[Create a fork]: https://help.github.com/en/articles/fork-a-repo
+[Create a fork]: https://docs.github.com/en/get-started/quickstart/fork-a-repo


### PR DESCRIPTION
This link does a 403 redirect to the new one, causing markdownlink-check
to fail.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
