### PR TITLE
Mark the source directory as safe

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,6 +9,8 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output PATH=${DAPPER_SOURCE}/bin/:${PATH}
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 # Override the Helm deployment scripts
 COPY deploy_helm /opt/shipyard/scripts/lib/
 


### PR DESCRIPTION
See https://github.blog/2022-04-12-git-security-vulnerability-announced/ for context. git now refuses to handle repositories which don't belong to the current user by default; such repositories need to be explicitly marked as safe, in the global configuration for the current user.

This should fix the failing [release job](https://github.com/submariner-io/submariner-charts/runs/6506404248?check_suite_focus=true).
