### PR TITLE
Automated backport of #230: Mark the source directory as safe

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -9,6 +9,8 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output PATH=${DAPPER_SOURCE}/bin/:${PATH}
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 # Override the Helm deployment scripts
 COPY deploy_helm /opt/shipyard/scripts/lib/
 


### PR DESCRIPTION
Backport of #230 on release-0.12.

#230: Mark the source directory as safe

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.