### PR TITLE
Create secrets along with SAs

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - k8s_version: '1.21'
           - k8s_version: '1.22'
+          - k8s_version: '1.24'
     steps:
       - name: Check out the repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/deploy_helm
+++ b/deploy_helm
@@ -27,8 +27,8 @@ function setup_broker() {
     fi
 
     submariner_broker_url=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
-    submariner_broker_ca=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-client')].data['ca\.crt']}")
-    submariner_broker_token=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${SUBMARINER_BROKER_NS}-client')].data.token}"|base64 --decode)
+    submariner_broker_ca=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data['ca\.crt']}")
+    submariner_broker_token=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data.token}"|base64 --decode)
 }
 
 function helm_install_subm() {

--- a/submariner-k8s-broker/templates/NOTES.txt
+++ b/submariner-k8s-broker/templates/NOTES.txt
@@ -6,5 +6,5 @@ You can retrieve the server URL by running
 
 The broker client token and CA can be retrieved by running
 
-  $ SUBMARINER_BROKER_CA=$(kubectl -n {{ .Release.Namespace }} get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='{{ template "submariner-k8s-broker.clientServiceAccountName" . }}')].data['ca\.crt']}")
-  $ SUBMARINER_BROKER_TOKEN=$(kubectl -n {{ .Release.Namespace }} get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='{{ template "submariner-k8s-broker.clientServiceAccountName" . }}')].data.token}"|base64 --decode)
+  $ SUBMARINER_BROKER_CA=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data['ca\.crt']}")
+  $ SUBMARINER_BROKER_TOKEN=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data.token}"|base64 --decode)

--- a/submariner-k8s-broker/templates/svc-acct.yaml
+++ b/submariner-k8s-broker/templates/svc-acct.yaml
@@ -8,4 +8,12 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner-k8s-broker.chart" . }}
     app: {{ template "submariner-k8s-broker.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner-k8s-broker.clientServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner-k8s-broker.clientServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}

--- a/submariner-operator/templates/svc-acct.yaml
+++ b/submariner-operator/templates/svc-acct.yaml
@@ -8,6 +8,14 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.operatorServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.operatorServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.gateway.create }}
@@ -20,6 +28,14 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.gatewayServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.gatewayServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.routeAgent.create }}
@@ -32,6 +48,14 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.routeAgentServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.routeAgentServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.globalnet.create }}
@@ -44,6 +68,14 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.globalnetServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.globalnetServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}
 ---
 {{- if .Values.serviceAccounts.lighthouseAgent.create }}
@@ -56,6 +88,14 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.lighthouseAgentServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.lighthouseAgentServiceAccountName" . }}
+type: kubernetes.io/service-account-token
 {{- end }}
 ---
   {{- if .Values.serviceAccounts.lighthouseCoreDns.create }}
@@ -68,4 +108,12 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "submariner.lighthouseCoreDnsServiceAccountName" . }}-token
+  annotations:
+    kubernetes.io/service-account.name: {{ template "submariner.lighthouseCoreDnsServiceAccountName" . }}
+type: kubernetes.io/service-account-token
   {{- end }}


### PR DESCRIPTION
Starting with Kubernetes 1.24, secrets are no longer automatically
created for SAs. This adds secrets to the relevant templates; creating
secrets in this way is supported in all Kubernetes versions.

Fixes: #236
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
