### PR TITLE
Add K8s 1.24 E2E, EoL K8s 1.21

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -16,12 +16,11 @@ jobs:
       matrix:
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.23']
+        k8s_version: ['1.24']
         lighthouse: ['', 'lighthouse']
         include:
-          - k8s_version: '1.21'
           - k8s_version: '1.22'
-          - k8s_version: '1.24'
+          - k8s_version: '1.23'
     steps:
       - name: Check out the repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
Use Kubernetes 1.24 as the default version for end-to-end tests.

Remove Kubernetes 1.21 end-to-end tests as it's end of life.

Depends on #237
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
