### PR TITLE
Use minimal clusters for E2E

### DIFF
--- a/.shipyard.e2e.ovn.yml
+++ b/.shipyard.e2e.ovn.yml
@@ -1,7 +1,7 @@
 ---
 cni: ovn
 submariner: true
-nodes: control-plane worker worker
+nodes: control-plane
 clusters:
   cluster1:
   cluster2:

--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,7 +1,7 @@
 ---
 cni: weave
 submariner: true
-nodes: control-plane worker
+nodes: control-plane
 clusters:
   cluster1:
   cluster2:


### PR DESCRIPTION
We don't really need to run the entire E2E suite anymore since we're
deploying the operator and it takes care of the entire deployment cycle.
Hence, the testing on operator should suffice and the helm testing can
be much slimmer and only use 2 single-node clusters.

This won't run the non-gw node tests, but as it's all tested on the
operator anyhow, there's no need to re-test it here.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
