### PR TITLE
Add submariner-gateway role permissions for leases

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -162,6 +162,17 @@ rules:
     - patch
     - update
     - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
This is needed for leader election resource locking in K8s 0.24.
