### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,29 +11,17 @@ PRELOAD_IMAGES := submariner-gateway submariner-operator submariner-route-agent 
 include $(SHIPYARD_DIR)/Makefile.inc
 
 ifneq (,$(filter ovn,$(_using)))
-CLUSTER_SETTINGS_FLAG = --settings $(DAPPER_SOURCE)/.shipyard.e2e.ovn.yml
+export SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.ovn.yml
 else
-CLUSTER_SETTINGS_FLAG = --settings $(DAPPER_SOURCE)/.shipyard.e2e.yml
+export SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG) --deploytool helm
-export DEPLOY_ARGS
+export DEPLOYTOOL = helm
 GH_URL=https://submariner-io.github.io/submariner-charts/charts
 CHARTS_DIR=charts
 CHARTS_VERSION=0.13.0-rc2
 HELM_DOCS_VERSION=0.15.0
 REPO_URL=$(shell git config remote.origin.url)
-
-# Process extra flags from the `using=a,b,c` optional flag
-
-ifneq (,$(filter lighthouse,$(_using)))
-override DEPLOY_ARGS += --service_discovery
-endif
-
-ifneq (,$(filter globalnet,$(_using)))
-override DEPLOY_ARGS += --globalnet
-endif
 
 # Targets to make
 


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends (no longer) on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
