### PR TITLE
Add support for image overrides

### DIFF
--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -23,6 +23,32 @@ spec:
   natEnabled: {{ .Values.submariner.natEnabled }}
   repository: {{ .Values.submariner.images.repository }}
   version: {{ .Values.submariner.images.tag }}
+{{- with .Values.images }}
+{{- if . }}
+  imageOverrides:
+    {{- if index . "submariner-operator" }}
+    submariner-operator: {{ index . "submariner-operator" }}
+    {{- end }}
+    {{- if index . "submariner-gateway" }}
+    submariner-gateway: {{ index . "submariner-gateway" }}
+    {{- end }}
+    {{- if index . "submariner-route-agent" }}
+    submariner-routeagent: {{ index . "submariner-route-agent" }}
+    {{- end }}
+    {{- if index . "submariner-globalnet" }}
+    submariner-globalnet: {{ index . "submariner-globalnet" }}
+    {{- end }}
+    {{- if index . "submariner-networkplugin-syncer" }}
+    submariner-networkplugin-syncer: {{ index . "submariner-networkplugin-syncer" }}
+    {{- end }}
+    {{- if index . "lighthouse-agent" }}
+    lighthouse-agent: {{ index . "lighthouse-agent" }}
+    {{- end }}
+    {{- if index . "lighthouse-coredns" }}
+    lighthouse-coredns: {{ index . "lighthouse-coredns" }}
+    {{- end }}
+{{- end }}
+{{- end }}
   serviceCIDR: "{{ .Values.submariner.serviceCidr }}"
   globalCIDR: "{{ .Values.submariner.globalCidr }}"
   serviceDiscoveryEnabled: {{ .Values.submariner.serviceDiscovery }}

--- a/submariner-operator/values.yaml
+++ b/submariner-operator/values.yaml
@@ -24,6 +24,7 @@ broker:
   globalnet: false
 rbac:
   create: true
+images: {}
 ipsec:
   psk: ""
   debug: false


### PR DESCRIPTION
Add support to override specific images (already supported by
submariner) to the helm chart.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
