### PR TITLE
Adjust LH image overrides to use component names

### DIFF
--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -42,10 +42,10 @@ spec:
     submariner-networkplugin-syncer: {{ index . "submariner-networkplugin-syncer" }}
     {{- end }}
     {{- if index . "lighthouse-agent" }}
-    lighthouse-agent: {{ index . "lighthouse-agent" }}
+    submariner-lighthouse-agent: {{ index . "lighthouse-agent" }}
     {{- end }}
     {{- if index . "lighthouse-coredns" }}
-    lighthouse-coredns: {{ index . "lighthouse-coredns" }}
+    submariner-lighthouse-coredns: {{ index . "lighthouse-coredns" }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Operator expects the component name, use it in the Submariner CR and not
the image name.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
