### PR TITLE
Don't specify images to preload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
 
-PRELOAD_IMAGES := submariner-gateway submariner-operator submariner-route-agent lighthouse-agent lighthouse-coredns
-
 include $(SHIPYARD_DIR)/Makefile.inc
 
 ifneq (,$(filter ovn,$(_using)))

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,15 @@ CHARTS_VERSION=0.13.0-rc2
 HELM_DOCS_VERSION=0.15.0
 REPO_URL=$(shell git config remote.origin.url)
 
+# TODO: Remove once a 0.14.0/0.13.1 helm chart is released
+# This is needed because the operator was erroneously using image names for overrides, and it has been fixed on devel
+# Also we need the fix https://github.com/submariner-io/lighthouse/pull/833
+ifeq ($(LIGHTHOUSE),true)
+ifeq ($(GLOBALNET),true)
+PRELOAD_IMAGES := lighthouse-agent lighthouse-coredns submariner-operator
+endif
+endif
+
 # Targets to make
 
 e2e: E2E_ARGS=cluster1 cluster2


### PR DESCRIPTION
Shipyard now preloads all built images,
there's no need to explicitly preload any images.

Depends on https://github.com/submariner-io/shipyard/pull/937

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
