### PR TITLE
Automated backport of #268: Use the default kind CNI

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,5 +1,4 @@
 ---
-cni: weave
 submariner: true
 nodes: control-plane worker
 clusters:


### PR DESCRIPTION
Backport of #268 on release-0.13.

#268: Use the default kind CNI

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.