### PR TITLE
Remove hard-coded latest version from the chart READMEs

### DIFF
--- a/submariner-k8s-broker/README.md
+++ b/submariner-k8s-broker/README.md
@@ -1,7 +1,5 @@
 # submariner-k8s-broker
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
-
 Submariner Kubernetes Broker
 
 **Homepage:** <https://submariner-io.github.io/>

--- a/submariner-operator/README.md
+++ b/submariner-operator/README.md
@@ -1,7 +1,5 @@
 # submariner-operator
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
-
 Submariner enables direct networking between Pods and Services in different Kubernetes clusters
 
 **Homepage:** <https://submariner-io.github.io/>
@@ -27,7 +25,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 | broker.server | string | `"example.k8s.apiserver"` |  |
 | broker.token | string | `"test"` |  |
 | gateway.image.repository | string | `"quay.io/submariner/submariner-gateway"` |  |
-| gateway.image.tag | string | `"0.14.0-m1"` |  |
+| gateway.image.tag | string | `"0.14.0"` |  |
 | ipsec.debug | bool | `false` |  |
 | ipsec.forceUDPEncaps | bool | `false` |  |
 | ipsec.ikePort | int | `500` |  |
@@ -39,7 +37,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 | operator.affinity | object | `{}` |  |
 | operator.image.pullPolicy | string | `"IfNotPresent"` |  |
 | operator.image.repository | string | `"quay.io/submariner/submariner-operator"` |  |
-| operator.image.tag | string | `"0.14.0-m1"` |  |
+| operator.image.tag | string | `"0.14.0"` |  |
 | operator.resources | object | `{}` |  |
 | operator.tolerations | list | `[]` |  |
 | rbac.create | bool | `true` |  |
@@ -64,7 +62,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 | submariner.globalCidr | string | `""` |  |
 | submariner.healthcheckEnabled | bool | `true` |  |
 | submariner.images.repository | string | `"quay.io/submariner"` |  |
-| submariner.images.tag | string | `"0.14.0-m1"` |  |
+| submariner.images.tag | string | `"0.14.0"` |  |
 | submariner.natEnabled | bool | `false` |  |
 | submariner.serviceCidr | string | `""` |  |
 | submariner.serviceDiscovery | bool | `true` |  |


### PR DESCRIPTION
...from the top shield banner

![image](https://user-images.githubusercontent.com/13009252/197231964-52f3101c-b8a3-4c65-a794-b667892adeeb.png)


I don't see any reason why we need that. This eliminates places we need to update when we release a new chart version. The other places where it references a version is in the sample values. I changed those to just 0.14.0 but we don't really need to update these as they're intended to be examples.
