### PR TITLE
Set chart appVersion with 'helm package' on release

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Set up helm/chart-testing
         uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec
 
+      - name: Set up local helm repo
+        run: make local-helm-repo
+
       - name: Run helm/chart-testing (lint)
         run: ct lint --config ct.yaml
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.tgz
 Makefile.dapper
 Dockerfile.*
+helm_repo

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_BRANCH ?= devel
 export BASE_BRANCH
-export HELM_REPO_LOCATION=.
+export HELM_REPO_LOCATION=./helm_repo
 
 ifneq (,$(DAPPER_HOST_ARCH))
 
@@ -25,11 +25,20 @@ export SUBCTL_VERSION
 
 # Targets to make
 
-e2e: E2E_ARGS=cluster1 cluster2
+CHART_PACKAGES := submariner-k8s-broker-$(CHARTS_VERSION).tgz submariner-operator-$(CHARTS_VERSION).tgz
+
+local-helm-repo: $(CHART_PACKAGES)
+	mkdir -p $(HELM_REPO_LOCATION)
+	for archive in $^; do \
+	  tar xzf $$archive -C $(HELM_REPO_LOCATION); \
+	done
+
+e2e: local-helm-repo
+	$(SCRIPTS_DIR)/e2e.sh
 
 %.tgz:
 	helm dep update $(subst -$(CHARTS_VERSION),,$(basename $(@F)))
-	helm package --version $(CHARTS_VERSION) $(subst -$(CHARTS_VERSION),,$(basename $(@F)))
+	helm package --version $(CHARTS_VERSION) --app-version $(CHARTS_VERSION) $(subst -$(CHARTS_VERSION),,$(basename $(@F)))
 
 helm-docs:
 	# Avoid polluting repo with helm-docs' README/LICENSE or other files in the release archive
@@ -45,7 +54,7 @@ helm-docs:
 		exit 1; \
 	fi
 
-release: submariner-k8s-broker-$(CHARTS_VERSION).tgz submariner-operator-$(CHARTS_VERSION).tgz
+release: $(CHART_PACKAGES)
 	git checkout gh-pages
 	mv *.tgz $(CHARTS_DIR)
 	if [ -f $(CHARTS_DIR)/index.yaml ]; then \

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,7 @@
 ---
 charts:
-  - submariner-operator
-  - submariner-k8s-broker
+  - ./helm_repo/submariner-operator
+  - ./helm_repo/submariner-k8s-broker
 # Tests that maintainer name is valid GitHub account, which isn't what we want
 # See: https://github.com/helm/chart-testing/issues/192
 validate-maintainers: false

--- a/submariner-k8s-broker/Chart.yaml
+++ b/submariner-k8s-broker/Chart.yaml
@@ -1,8 +1,7 @@
 ---
 name: submariner-k8s-broker
-version: 0.14.0-rc2
+version: 0.0.0
 apiVersion: v2
-appVersion: 0.14.0-rc2
 description: Submariner Kubernetes Broker
 keywords:
 home: https://submariner-io.github.io/

--- a/submariner-operator/Chart.yaml
+++ b/submariner-operator/Chart.yaml
@@ -1,8 +1,7 @@
 ---
 name: submariner-operator
-version: 0.14.0-rc2
+version: 0.0.0
 apiVersion: v2
-appVersion: 0.14.0-rc2
 description: Submariner enables direct networking between Pods and Services in different Kubernetes clusters
 keywords:
 home: https://submariner-io.github.io/


### PR DESCRIPTION
Use the `--app-version` parameter to `helm package` to dynamically set the chart `appVersion` field. We can then omit the hardcoded `appVersion` field in the _Chart.yaml_ file.

The chart `version` field is also set by `helm package` but we still need to define it in the _Chart.yaml_ file since `helm dep update` requires it. The placeholder `version` field is now set to _0.0.0_ just to give it some value.

For E2E, since the version fields are no longer hardcoded, it now simulates a release by running `helm package` and extracting the tar files to `HELM_REPO_LOCATION`, now set to _./helm_repo_.
