### PR TITLE
Keep notes's variables consistent with documents

### DIFF
--- a/submariner-k8s-broker/templates/NOTES.txt
+++ b/submariner-k8s-broker/templates/NOTES.txt
@@ -6,5 +6,5 @@ You can retrieve the server URL by running
 
 The broker client token and CA can be retrieved by running
 
-  $ SUBMARINER_BROKER_CA=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data['ca\.crt']}")
-  $ SUBMARINER_BROKER_TOKEN=$(kubectl -n "${SUBMARINER_BROKER_NS}" get secrets "${SUBMARINER_BROKER_NS}-client-token" -o jsonpath="{.data.token}"|base64 --decode)
+  $ SUBMARINER_BROKER_CA=$(kubectl -n "${BROKER_NS}" get secrets "${BROKER_NS}-client-token" -o jsonpath="{.data['ca\.crt']}")
+  $ SUBMARINER_BROKER_TOKEN=$(kubectl -n "${BROKER_NS}" get secrets "${BROKER_NS}-client-token" -o jsonpath="{.data.token}"|base64 --decode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
The variable names in NOTES.txt are inconsistent. If used alternately, an error will occur.