### PR TITLE
Add LH coredns permission to access Submariner resource

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -888,20 +888,10 @@ rules:
       - delete
       - deletecollection
   - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - "*"
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - delete
-  - apiGroups:
       - submariner.io
     resources:
       - "gateways"
+      - "submariners"
     verbs:
       - get
       - list


### PR DESCRIPTION
Addresses https://github.com/submariner-io/lighthouse/issues/936#issuecomment-1416197295.

This causes the lighthouse helm E2E to fail.

Also removed the permissions for the obsolete `lighthouse.submariner.io` group.
