### PR TITLE
Automated backport of #377: Bump chart version to 0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 export DEPLOYTOOL = helm
 GH_URL=https://submariner-io.github.io/submariner-charts/charts
 CHARTS_DIR=charts
-CHARTS_VERSION=0.14.0
+CHARTS_VERSION=0.15.0
 HELM_DOCS_VERSION=0.15.0
 REPO_URL=$(shell git config remote.origin.url)
 SUBCTL_VERSION=$(CHARTS_VERSION)

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -699,7 +699,6 @@ rules:
       - pods
       - namespaces
       - nodes
-      - endpoints
     verbs:
       - get
       - list
@@ -709,6 +708,7 @@ rules:
       - ""
     resources:
       - services
+      - endpoints
     verbs:
       - create
       - get
@@ -729,17 +729,11 @@ rules:
       - submariner.io
     resources:
       - clusterglobalegressips
+      - clusterglobalegressips/status
       - globalegressips
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - submariner.io
-    resources:
+      - globalegressips/status
       - globalingressips
+      - globalingressips/status
     verbs:
       - create
       - get


### PR DESCRIPTION
Backport of #377 on release-0.15.

#377: Bump chart version to 0.15.0

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.