### PR TITLE
Automated backport of #451: Add lease RBAC perm to submariner-globalnet role

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -370,6 +370,17 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Backport of #451 on release-0.16.

#451: Add lease RBAC perm to submariner-globalnet role

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.