### PR TITLE
Automated backport of #480: Use K8s 1.29 as latest in E2E

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -19,7 +19,7 @@ jobs:
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.28']
+        k8s_version: ['1.29']
         lighthouse: ['', 'lighthouse']
         include:
           # Bottom of supported K8s version range


### PR DESCRIPTION
Backport of #480 on release-0.17.

#480: Use K8s 1.29 as latest in E2E

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.