### PR TITLE
Automated backport of #508: Reduce RBAC permissions for the various components 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .shflags
 *.tgz
 Makefile.dapper
+Makefile.shipyard
 Dockerfile.*
 helm_repo

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -674,33 +674,18 @@ metadata:
   name: {{ template "submariner.fullname" . }}:lighthouse-coredns
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
       - discovery.k8s.io
     resources:
       - endpointslices
     verbs:
-      - create
       - get
       - list
       - watch
-      - update
-      - delete
-      - deletecollection
   - apiGroups:
       - submariner.io
     resources:
-      - "gateways"
-      - "submariners"
+      - gateways
+      - submariners
     verbs:
       - get
       - list
@@ -708,14 +693,11 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "*"
+      - serviceimports
     verbs:
-      - create
       - get
       - list
       - watch
-      - update
-      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -9,62 +9,77 @@ metadata:
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - {{ template "submariner.fullname" . }}
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - submariner.io
-  resources:
-  - '*'
-  - servicediscoveries
-  verbs:
-  - '*'
+  - apiGroups:
+      - ""
+    resources:
+      # For metrics
+      - services
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      # Temporarily needed for network-plugin syncer removal
+      - serviceaccounts
+    resourceNames:
+      - submariner-networkplugin-syncer
+    verbs:
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      # Needed for openshift monitoring
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - {{ template "submariner.fullname" . }}
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - submariner.io
+    resources:
+      - brokers
+      - brokers/status
+      - submariners
+      - submariners/status
+      - servicediscoveries
+      - servicediscoveries/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - submariner.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -435,9 +450,10 @@ rules:
       - update
       - delete
       - watch
-  - apiGroups:  # pods, services and nodes are looked up to figure out network settings
+  - apiGroups:
       - ""
     resources:
+      # Needed for network settings discovery
       - pods
       - services
       - nodes
@@ -451,27 +467,20 @@ rules:
       - dnses
     verbs:
       - get
-      - list
-      - watch
       - update
   - apiGroups:
       - config.openshift.io
     resources:
+      # Needed for network settings discovery
       - networks
+    resourceNames:
+      - cluster
     verbs:
       - get
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - monitoring.coreos.com
     resources:
+      # Needed for openshift monitoring
       - servicemonitors
     verbs:
       - get
@@ -479,11 +488,21 @@ rules:
   - apiGroups:
       - apps
     resources:
+      # Needed for Flannel CNI discovery
       - daemonsets
     verbs:
-      - get
       - list
-      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      # Temporarily needed for network-plugin syncer removal
+      - clusterroles
+      - clusterrolebindings
+    resourceNames:
+      - ocp-submariner-networkplugin-syncer
+      - submariner-networkplugin-syncer
+    verbs:
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -170,74 +170,25 @@ metadata:
     app: {{ template "submariner.name" . }}
 rules:
   - apiGroups:
-      - ""
+      - submariner.io
     resources:
-      - pods
-      - services
-      - services/finalizers
       - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
     verbs:
       - get
-      - create
-  - apiGroups:
-      - apps
-    resourceNames:
-      - submariner-operator
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
+      - list
+      - watch
   - apiGroups:
       - submariner.io
     resources:
-      - '*'
-      - servicediscoveries
+      - gatewayroutes
+      - nongatewayroutes
     verbs:
-      - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
       - watch
+      - create
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -555,56 +506,41 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  - apiGroups:  # pods and services are looked up to figure out network settings
-      - ""
-    resources:
       - pods
       - services
+      - secrets
+      - configmaps
+      - endpoints
     verbs:
       - get
       - list
-      - watch
-  - apiGroups:
-      - operator.openshift.io
-    resources:
-      - dnses
-    verbs:
-      - get
-      - list
-      - watch
-      - update
   - apiGroups:
       - config.openshift.io
     resources:
       - networks
+    resourceNames:
+      - cluster
     verbs:
       - get
-      - list
   - apiGroups:
       - ""
+    resources:
+      - nodes
     verbs:
       - get
       - list
       - watch
       - update
+  - apiGroups:
+      - projectcalico.org
     resources:
-      - nodes
+      - ippools
+    verbs:
+      - get
+      - create
+      - delete
+      - update
+      - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -108,86 +108,38 @@ metadata:
     chart: {{ template "submariner.chart" . }}
     app: {{ template "submariner.name" . }}
 rules:
-- apiGroups:
-    - ""
-  resources:
-    - pods
-    - services
-    - services/finalizers
-    - endpoints
-    - persistentvolumeclaims
-    - events
-    - configmaps
-    - secrets
-  verbs:
-    - '*'
-- apiGroups:
-    - apps
-  resources:
-    - deployments
-    - daemonsets
-    - replicasets
-    - statefulsets
-  verbs:
-    - '*'
-- apiGroups:
-    - monitoring.coreos.com
-  resources:
-    - servicemonitors
-  verbs:
-    - get
-    - create
-- apiGroups:
-    - apps
-  resourceNames:
-    - submariner-operator
-  resources:
-    - deployments/finalizers
-  verbs:
-    - update
-- apiGroups:
-    - ""
-  resources:
-    - pods
-  verbs:
-    - get
-- apiGroups:
-    - apps
-  resources:
-    - replicasets
-  verbs:
-    - get
-- apiGroups:
-    - submariner.io
-  resources:
-    - '*'
-    - servicediscoveries
-  verbs:
-    - '*'
-- apiGroups:
-    - lighthouse.submariner.io
-  resources:
-    - '*'
-    - serviceexports
-  verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
-  verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - clusters
+      - endpoints
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -561,52 +513,12 @@ rules:
       - configmaps
     verbs:
       - get
-      - list
-      - watch
-      - create
-      - update
   - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-  - apiGroups:  # pods and services are looked up to figure out network settings
       - ""
     resources:
       - pods
       - services
       - nodes
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - operator.openshift.io
-    resources:
-      - dnses
-    verbs:
-      - get
-      - list
-      - watch
-      - update
-  - apiGroups:
-      - config.openshift.io
-    resources:
-      - networks
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - submariner.io
-    resources:
-      - endpoints
-      - gateways
-      - clusters
     verbs:
       - get
       - list

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -220,75 +220,6 @@ metadata:
     app: {{ template "submariner.name" . }}
 rules:
   - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - services/finalizers
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
-  - apiGroups:
-      - apps
-    resourceNames:
-      - submariner-operator
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-  - apiGroups:
-      - apps
-    resources:
-      - replicasets
-    verbs:
-      - get
-  - apiGroups:
-      - submariner.io
-    resources:
-      - '*'
-      - servicediscoveries
-    verbs:
-      - '*'
-  - apiGroups:
-      - lighthouse.submariner.io
-    resources:
-      - '*'
-      - serviceexports
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -574,14 +505,20 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods
-      - namespaces
       - nodes
     verbs:
       - get
       - list
       - watch
       - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -597,8 +534,8 @@ rules:
   - apiGroups:
       - submariner.io
     resources:
-      - endpoints
       - clusters
+      - endpoints
     verbs:
       - get
       - list
@@ -623,7 +560,7 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "serviceexports"
+      - serviceexports
     verbs:
       - get
       - list

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -615,7 +615,6 @@ rules:
       - get
       - list
       - watch
-      - update
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -632,8 +631,8 @@ rules:
   - apiGroups:
       - submariner.io
     resources:
-      - "gateways"
-      - "globalingressips"
+      - gateways
+      - globalingressips
     verbs:
       - get
       - list
@@ -641,7 +640,8 @@ rules:
   - apiGroups:
       - multicluster.x-k8s.io
     resources:
-      - "*"
+      - serviceimports
+      - serviceimports/status
     verbs:
       - create
       - get
@@ -649,6 +649,20 @@ rules:
       - watch
       - update
       - delete
+  - apiGroups:
+      - multicluster.x-k8s.io
+    resources:
+      - serviceexports
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - multicluster.x-k8s.io
+    resources:
+      - serviceexports/status
+    verbs:
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -21,6 +21,16 @@ rules:
   - apiGroups:
       - ""
     resources:
+      # For syncing Secrets from the broker
+      - secrets
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
       # Temporarily needed for network-plugin syncer removal
       - serviceaccounts
     resourceNames:


### PR DESCRIPTION
Backport of #508 on release-0.16.

#508: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

**Note**: This also includes the RBAC changes from https://github.com/submariner-io/submariner-operator/pull/3050.