### PR TITLE
Add RBAC access to finalizers for the operator role

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -80,6 +80,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
On Openshift, the operator failed with error

"_\"submariner-gateway\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on_"

Openshift enables [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement), so in order to set `blockOwnerDeletion` for an object, the user needs update permission for the finalizers subresource of the referenced owner. In this case the owner is the `Submariner` object.