### PR TITLE
Automated backport of #515: Add RBAC access to finalizers for the operator role

### DIFF
--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -81,6 +81,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - submariner.io
+    resources:
+      - submariners/finalizers
+      - servicediscoveries/finalizers
+    verbs:
+      - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Backport of #515 on release-0.14.

#515: Add RBAC access to finalizers for the operator role

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.