### PR TITLE
Enable leader election in the operator

### DIFF
--- a/submariner-operator/templates/operator-deployment.yaml
+++ b/submariner-operator/templates/operator-deployment.yaml
@@ -27,8 +27,8 @@ spec:
         name: {{ template "submariner.fullname" . }}
     spec:
       containers:
-      - command:
-        - submariner-operator
+      - args:
+        - --leader-elect
         env:
         - name: WATCH_NAMESPACE
           valueFrom:

--- a/submariner-operator/templates/rbac.yaml
+++ b/submariner-operator/templates/rbac.yaml
@@ -87,6 +87,17 @@ rules:
       - servicediscoveries/finalizers
     verbs:
       - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The operator no longer runs leader-for-life election so enable leader-with-lease via the CLI arg in the pod spec.

Depends on https://github.com/submariner-io/submariner-operator/pull/3299