### PR TITLE
Automated backport of #640: Use named Kubernetes versions in GHAs

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -19,11 +19,11 @@ jobs:
         cable_driver: ['libreswan', 'wireguard', 'vxlan']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.29']
+        k8s_version: ['k8s-latest']
         lighthouse: ['', 'lighthouse']
         include:
           # Bottom of supported K8s version range
-          - k8s_version: '1.26'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Backport of #640 on release-0.18.

#640: Use named Kubernetes versions in GHAs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.