### PR TITLE
(feat): add conditional support for GitOps utilizing CRD spec.brokerK…

### DIFF
--- a/submariner-operator/README.md
+++ b/submariner-operator/README.md
@@ -52,5 +52,6 @@ Submariner enables direct networking between Pods and Services in different Kube
 | submariner.images.tag | string | `"0.14.0"` |  |
 | submariner.natEnabled | bool | `false` |  |
 | submariner.serviceCidr | string | `""` |  |
+| submariner.brokerK8sSecret | string | `""` |  Name of the Kubernetes Secret containing broker credentials (ca.crt, token). |
 | submariner.serviceDiscovery | bool | `true` |  |
 | submariner.token | string | `""` |  |

--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -6,8 +6,12 @@ metadata:
 spec:
   broker: k8s
   brokerK8sApiServer: {{ .Values.broker.server }}
+  {{- if .Values.submariner.brokerK8sSecret }}
+  brokerK8sSecret: {{ .Values.submariner.brokerK8sSecret }}
+  {{- else }}
   brokerK8sApiServerToken: {{ .Values.broker.token }}
   brokerK8sCA: {{ .Values.broker.ca }}
+  {{- end }}
   brokerK8sRemoteNamespace: {{ .Values.broker.namespace }}
   brokerK8sInsecure: {{ .Values.broker.insecure }}
   ceIPSecDebug: {{ .Values.ipsec.debug }}

--- a/submariner-operator/values.yaml
+++ b/submariner-operator/values.yaml
@@ -7,6 +7,7 @@ submariner:
   globalCidr: ""
   clustersetIpCidr: ""
   clustersetIpEnabled: false
+  brokerK8sSecret: ""
   loadBalancerEnabled: false
   natEnabled: false
   colorCodes: blue


### PR DESCRIPTION
Addressing #695

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new submariner.brokerK8sSecret option (default "") allowing broker credentials to be provided via a Kubernetes Secret; when set, secret-based auth is used instead of inline broker credential fields.
* **Documentation**
  * Updated configuration docs and values reference to describe the new brokerK8sSecret parameter, default value, and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->