### PR TITLE
feat(operator): add ceIPSecPSKSecret support

### DIFF
--- a/submariner-operator/README.md
+++ b/submariner-operator/README.md
@@ -28,6 +28,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 | ipsec.forceUDPEncaps | bool | `false` |  |
 | ipsec.ikePort | int | `500` |  |
 | ipsec.natPort | int | `4500` |  |
+| ipsec.pskSecret | string | `""` | Name of the Kubernetes Secret containing the IPsec PSK as field psk |
 | ipsec.psk | string | `""` |  |
 | leadership.leaseDuration | int | `10` |  |
 | leadership.renewDeadline | int | `5` |  |

--- a/submariner-operator/templates/submariner.yaml
+++ b/submariner-operator/templates/submariner.yaml
@@ -18,7 +18,11 @@ spec:
   ceIPSecForceUDPEncaps: {{ .Values.ipsec.forceUDPEncaps }}
   ceIPSecIKEPort: {{ .Values.ipsec.ikePort }}
   ceIPSecNATTPort: {{ .Values.ipsec.natPort }}
+  {{- if .Values.ipsec.pskSecret }}
+  ceIPSecPSKSecret: {{ .Values.ipsec.pskSecret }}
+  {{- else }}
   ceIPSecPSK: {{ .Values.ipsec.psk }}
+  {{- end }}
   clusterCIDR: "{{ .Values.submariner.clusterCidr }}"
   clusterID: {{ .Values.submariner.clusterId }}
   colorCodes: {{ .Values.submariner.colorCodes }}

--- a/submariner-operator/values.yaml
+++ b/submariner-operator/values.yaml
@@ -29,6 +29,7 @@ broker:
 images: {}
 ipsec:
   psk: ""
+  pskSecret: ""
   debug: false
   forceUDPEncaps: false
   ikePort: 500


### PR DESCRIPTION
Addressing #695 as well adding support for ceIPSecPSKSecret and not only for brokerK8sSecret

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for storing IPsec Pre-Shared Keys in Kubernetes Secrets; configuration can reference an existing Secret as an alternative to inline PSK values.

* **Documentation**
  * README updated with guidance for the new IPsec Secret configuration option and how to reference a secret containing the PSK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->