### PR TITLE
Fix MD060 table-column-style errors for markdownlint 0.48.0

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,6 +2,9 @@
 # Breaks reusing MD snippets extracted to files
 first-line-heading: false
 
+# Accept any consistent table column style
+table-column-style: false
+
 # Set maximum line Length to 140c to match Go linting
 line-length:
   line_length: 140

--- a/submariner-operator/README.md
+++ b/submariner-operator/README.md
@@ -17,7 +17,7 @@ Submariner enables direct networking between Pods and Services in different Kube
 ## Values
 
  | Key | Type | Default | Description |
- |-----|------|---------|-------------|
+ | ----- | ------ | --------- | ------------- |
  | broker.ca | string | `""` |  |
  | broker.globalnet | bool | `false` |  |
  | broker.insecure | bool | `false` |  |


### PR DESCRIPTION
- Add consistent spacing to table separator row in _submariner-operator/README.md_
- Disable MD060 rule in _.markdownlint.yml_ as tables use padded style with empty cells that the rule incorrectly flags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated markdown linting configuration to support consistent table formatting across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->